### PR TITLE
Add CLI regression testing

### DIFF
--- a/test/test_regression_cli.py
+++ b/test/test_regression_cli.py
@@ -3,9 +3,9 @@ import nose
 from hashlib import md5
 
 # First md5 is for csv, second md5 is for sqlite
-known_md5s_sqlite = {'AvianBodySize' : 'bbf85e30cd05b622da71508ee70d3b5f',
-                     'DelMoral2010' : '2630b6db704d88def23bca8929c24ce0',
-                     'MoM2003' : 'be9c50ef09542b552009aeba767977fe'}
+known_md5s_sqlite = {'AvianBodySize' : '72256f681cdce96eba32d4ece270bcb2',
+                     'DelMoral2010' : '92b6cd535f8e6c82d6fc19802d6ba64f',
+                     'MoM2003' : 'd3bdce86e0fc5888449884dfb0ef4611'}
 
 known_md5s_csv = {'AvianBodySize' : 'f42702a53e7d99d16e909676f30e5aa8',
                   'DelMoral2010' : '606f97c3ddbfd6d63b474bc76d01646a',
@@ -26,8 +26,9 @@ def test_sqlite_regression():
         
 def check_sqlite_regression(dataset, known_md5):
     """Check for regression for a particular dataset imported to sqlite"""
-    os.system("rm output_file") #reinstalling changes checksum in sqlite
-    os.system("retriever install sqlite %s -f output_file" % dataset)
+    os.system("rm output_database") #reinstalling changes checksum in sqlite
+    os.system("retriever install sqlite %s -f output_database" % dataset)
+    os.system("echo '.dump' | sqlite3 output_database > output_file")
     current_md5 = getmd5('output_file')
     assert current_md5 == known_md5
 


### PR DESCRIPTION
Adds high-level regression testing by installing datasets using the CLI and comparing the results
to the current results based on md5 checksums.

Currently tests only engines that directly produce files (csv and sqlite) and includes tests of
three datasets that cover the range of complexity for simple text scripts (AvianBodySize,
DelMoral2010, and MoM2003).

If there are better ways to do this I'm certainly open to reworking things. I'm viewing this as the
highest level safety net to allow us to do any necessary refactoring to make it easier to write more
specific tests.
