### PR TITLE
Rename and clarify behavior of tests.py

### DIFF
--- a/try_install_all.py
+++ b/try_install_all.py
@@ -9,7 +9,6 @@ see if there are any errors. It does not check the values in the database.
 """
 
 import os
-import unittest
 from retriever.lib.tools import choose_engine
 from retriever import MODULE_LIST, ENGINE_LIST, SCRIPT_LIST
 


### PR DESCRIPTION
tests.py attempts to install all datasets using all engines and logs errors. It does not use
a standard unit testing framework and it seems undesirable to regularly run this script as
part of testing.
1. It has been renamed it to reflect more clearly what it does and to prevent it from being
   executed by nose.
2. The unused `unittest` import has been removed.
3. The docstring has been clarified.
