### PR TITLE
get_insert_columns() is now in Table()

### DIFF
--- a/engines/msaccess.py
+++ b/engines/msaccess.py
@@ -77,7 +77,7 @@ class engine(Engine):
             else:
                 hdr = "No"
 
-            columns = self.get_insert_columns()
+            columns = self.table.get_insert_columns()
 
             need_to_delete = False
             add_to_record_id = 0

--- a/engines/mysql.py
+++ b/engines/mysql.py
@@ -53,7 +53,7 @@ class engine(Engine):
             ):
             print ("Inserting data from " + os.path.basename(filename) + "...")
             
-            columns = self.get_insert_columns()            
+            columns = self.table.get_insert_columns()
             statement = """        
 LOAD DATA LOCAL INFILE '""" + filename.replace("\\", "\\\\") + """'
 INTO TABLE """ + self.tablename() + """

--- a/engines/postgres.py
+++ b/engines/postgres.py
@@ -75,7 +75,7 @@ class engine(Engine):
             and not ct
             and (not hasattr(self.table, "do_not_bulk_insert") or not self.table.do_not_bulk_insert)
             ):
-            columns = self.get_insert_columns()    
+            columns = self.table.get_insert_columns()
             filename = os.path.abspath(filename)
             statement = """
 COPY """ + self.tablename() + " (" + columns + """)


### PR DESCRIPTION
Fixes a bug introduced during the refactor of engine.py that broke
MySQL, PostgreSQL, and MS Access imports.
