### PR TITLE
Reset the database connection after MySQL bulk insert failure

### DIFF
--- a/engines/mysql.py
+++ b/engines/mysql.py
@@ -66,7 +66,7 @@ IGNORE """ + str(self.table.header_rows) + """ LINES
                 self.cursor.execute(statement)
             except Exception as e:
                 print "Failed bulk insert (%s), inserting manually" % e
-                self.reset_connection() # If the execute fails the database connection can get hung up
+                self.disconnect() # If the execute fails the database connection can get hung up
                 return Engine.insert_data_from_file(self, filename)
         else:
             return Engine.insert_data_from_file(self, filename)

--- a/lib/engine.py
+++ b/lib/engine.py
@@ -47,12 +47,6 @@ class Engine():
         '''This method should be overloaded by specific implementations
         of Engine.'''
         pass
-
-    def reset_connection(self):
-        """Reset the database connection"""
-        self.disconnect()
-        self.get_connection()
-        self.get_cursor()
     
     def add_to_table(self, data_source):
         """This function adds data to a table from one or more lines specified 


### PR DESCRIPTION
After a bulk insert failure in MySQL (caused by servers not
allowing this by default) we fall back to a line by line insert.
However, using pymysql the failed insert causes the database
connection to get hung up.

This commit creates a new method to reset the connection and
calls it prior to starting the line by line insert.

Fixes #93.
