### PR TITLE
If at CLI ls is run before update, automatically download scripts

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -84,6 +84,13 @@ def main():
         if args.command == 'ls' or args.dataset is None:
             import lscolumns
 
+            #If scripts have never been downloaded there is nothing to list
+            if not script_list:
+                print "No scripts are currently available. Updating scripts now..."
+                check_for_updates(graphical=False)
+                print "\n\nScripts downloaded.\n"
+                script_list = SCRIPT_LIST()
+
             all_scripts = set([script.shortname for script in script_list])
             all_tags = set(["ALL"] + 
                             [tag.strip().upper() for script in script_list for tagset in script.tags for tag in tagset.split('>')])


### PR DESCRIPTION
Running ls before update at the CLI was resulting in a error
because there were no datasets to display.

This change results in the automatic downloading of the current
scripts if none are available when ls is called.

Fixes #119.
