### PR TITLE
Make PyMySQL work inside App generated by py2app

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup(name='retriever',
       setup_requires=['py2app'] if 'darwin' in p else [],
 
       # options
+      # optimize is set to 1 of py2app to avoid errors with pymysql
       options = {'py2exe': {'bundle_files': 1,
                             'compressed': 2,
                             'optimize': 2,
@@ -108,7 +109,7 @@ setup(name='retriever',
                             'includes': includes,
                             'site_packages': True,
                             'resources': [],
-                            'optimize': 2,
+                            'optimize': 1,
                             'argv_emulation': True,
                             'no_chdir': True,
                             },


### PR DESCRIPTION
Setting the 'optimize' level to 2 was causing pymysql imports to
fail. This sets the 'optimize' level to 1, which only results in
a 1 MB increase in size and solves the issue.

8 hours worth of debugging for a 1 character change.

Fixes #144 and #145.
