### PR TITLE
Save full path of database when saving connections involving files

### DIFF
--- a/lib/tools.py
+++ b/lib/tools.py
@@ -212,6 +212,8 @@ def save_connection(engine_name, values_dict):
         config = open(config_path, "wb")
     else:
         config = open(config_path, "wb")
+    if "file" in values_dict:
+        values_dict["file"] = os.path.abspath(values_dict["file"])
     config.write(engine_name + "," + str(values_dict))
     for line in lines:
         config.write(line)


### PR DESCRIPTION
This seems like the better behavior if a file with a relative
path is entered when making a connection.
