### PR TITLE
Force connection wizard to be large enough for 'choose file' button

### DIFF
--- a/app/connect_wizard.py
+++ b/app/connect_wizard.py
@@ -95,6 +95,14 @@ class ChooseDbPage(TitledPage):
         else:
             self.dblist.SetSelection(0)
         self.sizer.Add(self.dblist, -1, wx.EXPAND)
+
+        #TODO: This is a hack to force the wizard to be large enough to not hide
+        #the Choose button on the Connect Page when the engine has a file
+        #attribute. This should be fixed properly by figuring out how to make wx
+        #work with the fact that the connect page has varying fields depending
+        #on the engine.
+        longspace = StaticText(self, -1, "", wx.Size(375, -1))
+        self.sizer.Add(longspace, -1)
         
     def dirbtn_click(self, evt):
         dialog = wx.DirDialog(None, message="Choose a directory to " +


### PR DESCRIPTION
Because (probably) app.ConnectPage.Draw contains different fields
depending on the engine, wx is not properly accommodating the
varying sizes of this page that might result. In cases where there
is a file attribute (sqlite, MS Access) the wizard is too small
on some systems and the button is cut off.

This is a hack that temporarily addresses this problem by adding
a large empty text box to the bottom of the first page of the
wizard. This probably should be fixed properly when time allows.

Also includes a minor refactor.

Fixes #154.
