### PR TITLE
By default create file based databases in Downloads dir on Windows

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -9,6 +9,7 @@ import os
 from os.path import join, isfile, getmtime, exists
 import imp
 from lib.compile import compile_script
+import platform
 
 
 VERSION = 'v1.5'
@@ -42,6 +43,11 @@ DATA_SEARCH_PATHS =     [
                          ]
 DATA_WRITE_PATH =       DATA_SEARCH_PATHS[-1]
 
+# create a default data directory for Windows since the Windows installer places
+# the executable in a place where users won't expect the data to be stored.
+current_platform = platform.platform().lower()
+user_home_dir = os.path.expanduser('~')
+DATA_DIR = user_home_dir if "win" in current_platform else '.'
 
 def MODULE_LIST(force_compile=False):
     """Load scripts from scripts directory and return list of modules."""

--- a/engines/csv.py
+++ b/engines/csv.py
@@ -1,7 +1,7 @@
 import os
 import platform
 from retriever.lib.models import Engine, no_cleanup
-
+from retriever import DATA_DIR
 
 class DummyConnection:
     def cursor(self):
@@ -33,9 +33,9 @@ class engine(Engine):
     required_opts = [
                      ("table_name",
                       "Format of table name",
-                      "{db}_{table}.csv"),
+                      os.path.join(DATA_DIR, "{db}_{table}.csv")),
                      ]
-                      
+
     def create_db(self):
         return None
         

--- a/engines/msaccess.py
+++ b/engines/msaccess.py
@@ -1,7 +1,7 @@
 import os
 import platform
 from retriever.lib.models import Engine, no_cleanup
-
+from retriever import DATA_DIR
 
 class engine(Engine):
     """Engine instance for Microsoft Access."""
@@ -19,7 +19,7 @@ class engine(Engine):
                  }
     required_opts = [("file", 
                       "Enter the filename of your Access database",
-                      "access.mdb",
+                      os.path.join(DATA_DIR, "access.mdb"),
                       "Access databases (*.mdb, *.accdb)|*.mdb;*.accdb"),
                      ("table_name",
                       "Format of table name",

--- a/engines/sqlite.py
+++ b/engines/sqlite.py
@@ -1,7 +1,7 @@
 import os
 import platform
 from retriever.lib.models import Engine, no_cleanup
-
+from retriever import DATA_DIR
 
 class engine(Engine):
     """Engine instance for SQLite."""
@@ -18,7 +18,7 @@ class engine(Engine):
                  }
     required_opts = [("file", 
                       "Enter the filename of your SQLite database",
-                      "sqlite.db",
+                      os.path.join(DATA_DIR, "sqlite.db"),
                       ""),
                      ("table_name",
                       "Format of table name",


### PR DESCRIPTION
Since the Windows installer places the executable in a location where most
users won't look, the Downloads folder is set to be the default on Windows.
This can be overridden by specifying the directory in the file or
table_name field.
