### PR TITLE
Add a command line usage section to the  README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ optional arguments:
   -q, --quiet           suppress command-line output
 ```
 
-To install datasets, use <code>retriever install</code>:
+To install datasets, use `retriever install`:
 
 ```
 usage: retriever install [-h] [--compile] [--debug]


### PR DESCRIPTION
I added a section to the README file that includes some of the instructions posted here: http://ecodataretriever.org/cli.html . However, some of the instructions on that website now appear to be out-dated and therefore it is important to document the current usage of the command line interface. Specifically this addition provides the correct example of how to use <code>retriever install</code> as the name of the dataset is no longer the first argument provided and the specification of the database format has changed. Hopefully this will be helpful to others.
