### PR TITLE
Make sure that CITATION is added to distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include CITATION


### PR DESCRIPTION
This adds a MANIFEST.in file to make sure that CITATION is included
in distributions. This should be handled by the data_files line in
setup.py, but that isn't working. This was apparently a bug in
Python 2.6 that was fixed, but there are reports of continued
issues in 2.7 http://stackoverflow.com/a/2998311/133513.

Fixes #190.
