### PR TITLE
Remove download only scripts from version.txt

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,7 +1,6 @@
 v1.6
 bbs.py
 bbs50stop.py
-bioclim_2pt5.py
 EA_adler2007.script
 EA_avianbodysize2007.script
 EA_barnes2008.script
@@ -20,8 +19,6 @@ EA_woods2009.script
 EA_zachmann2010.script
 fia.py
 gentry.py
-MammalDiet.script
-MammalSuperTree.py
 npn.py
 USDA_plants.script
 fia.py


### PR DESCRIPTION
The presence of these scripts breaks the current release, which doesn't
know how to handle these scripts.
