### PR TITLE
Remove download only scripts from version.txt

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,7 +1,6 @@
 v1.6
 bbs.py
 bbs50stop.py
-bioclim_2pt5.py
 EA_adler2007.script
 EA_avianbodysize2007.script
 EA_barnes2008.script
@@ -21,7 +20,6 @@ EA_zachmann2010.script
 fia.py
 gentry.py
 MammalDiet.script
-MammalSuperTree.py
 npn.py
 USDA_plants.script
 fia.py


### PR DESCRIPTION
The presence of these scripts breaks the existing release because it doesn't
know how to handle them. See #180 and #199.
