### PR TITLE
Fix flag in Inno Setup script

### DIFF
--- a/retriever_installer.iss
+++ b/retriever_installer.iss
@@ -26,7 +26,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
-Name: modifypath; Description: Add application directory to your environmental path; Flags: checked
+Name: modifypath; Description: Add application directory to your environmental path
 
 [Files]
 Source: "dist\retriever.exe"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
The proper way to have a checked option box is apparently to not set
a flag at all.

Oddly, the previous version must have worked for the last release,
but it doesn't work now.
