### PR TITLE
Allow either wxPython 2.8 or 3.0 for Debian package

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
-Depends: python-xlrd, python-wxgtk2.8, python-mysqldb, python-psycopg2
+Depends: python-xlrd, python-wxgtk2.8 | python-wxgtk3.0, python-mysqldb, python-psycopg2
 XS-Python-Version: >= 2.6


### PR DESCRIPTION
The current testing version of Debian only includes wxPython 3.0.
Since the name of the Debian package includes the version number this
means that the Debian package needs to allow 3.0 as well as 2.8 to
support both current and future Debian and Debian derived Linux distributions.

Thanks to @cboettig for pointing this out.

Fixes #247.
