### PR TITLE
Improve column name replacement

### DIFF
--- a/lib/table.py
+++ b/lib/table.py
@@ -45,7 +45,8 @@ class Table:
         '''Makes sure a column name is formatted correctly by removing reserved 
         words, symbols, numbers, etc.'''
         column_name = column_name.lower()
-        
+        replace_columns = [(old.lower(), new.lower())
+                           for old, new in self.replace_columns]
         replace = [
                    ("%", "percent"),
                    ("&", "and"),
@@ -56,7 +57,7 @@ class Table:
                    ("long", "lon"),
                    ("date", "record_date"),
                    ("?", ""),
-                   ] + self.replace_columns
+                   ] + replace_columns
         replace += [(x, '') for x in (")", "\n", "\r", '"', "'")]
         replace += [(x, '_') for x in (" ", "(", "/", ".", "-")]
         column_name = reduce(lambda x, y: x.replace(*y), replace, column_name)

--- a/lib/table.py
+++ b/lib/table.py
@@ -45,8 +45,9 @@ class Table:
         '''Makes sure a column name is formatted correctly by removing reserved 
         words, symbols, numbers, etc.'''
         column_name = column_name.lower()
-        replace_columns = [(old.lower(), new.lower())
-                           for old, new in self.replace_columns]
+        replace_columns = {old.lower(): new.lower()
+                           for old, new in self.replace_columns}
+        column_name = replace_columns.get(column_name, column_name)
         replace = [
                    ("%", "percent"),
                    ("&", "and"),
@@ -57,7 +58,7 @@ class Table:
                    ("long", "lon"),
                    ("date", "record_date"),
                    ("?", ""),
-                   ] + replace_columns
+                   ]
         replace += [(x, '') for x in (")", "\n", "\r", '"', "'")]
         replace += [(x, '_') for x in (" ", "(", "/", ".", "-")]
         column_name = reduce(lambda x, y: x.replace(*y), replace, column_name)


### PR DESCRIPTION
1. Do the replacement when original names are capitalized
2. Don't accidentally replace pieces of column names when original names are simple