### PR TITLE
Add control of the scope of a reset

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -10,17 +10,16 @@ The main() function can be used for bootstrapping.
 import os
 import platform
 import sys
-import shutil
 # sys removes the setdefaultencoding method at startup; reload to get it back
 reload(sys)
 if hasattr(sys, 'setdefaultencoding'):
     # set default encoding to latin-1 to avoid ascii encoding issues
     sys.setdefaultencoding('latin-1')
-from retriever import VERSION, MASTER, SCRIPT_LIST, sample_script, HOME_DIR
+from retriever import VERSION, MASTER, SCRIPT_LIST, sample_script
 from retriever.engines import engine_list
 from retriever.lib.repository import check_for_updates
 from retriever.lib.lists import Category, get_lists
-from retriever.lib.tools import choose_engine, name_matches
+from retriever.lib.tools import choose_engine, name_matches, reset_retriever
 from retriever.lib.get_opts import parser
 
 
@@ -83,22 +82,7 @@ def main():
             return
 
         elif args.command == 'reset':
-            warn_msg = """This will remove existing scripts, cached data, and
-information on database connections. Specifically it will remove
-the scripts and raw_data folders and the connections.config file
-in {}
-Do you want to proceed? (y/N)\n""".format(HOME_DIR)
-            confirm = raw_input(warn_msg)
-            while not (confirm.lower() in ['y', 'n', '']):
-                print("Please enter either y or n.")
-                confirm = raw_input(warn_msg)
-            if confirm.lower() == 'y':
-                shutil.rmtree(os.path.join(HOME_DIR, 'raw_data'))
-                shutil.rmtree(os.path.join(HOME_DIR, 'scripts'))
-                try:
-                    os.remove(os.path.join(HOME_DIR, 'connections.config'))
-                except:
-                    pass
+            reset_retriever(args.scope)
             return
 
         if args.command == 'ls' or args.dataset is None:

--- a/lib/get_opts.py
+++ b/lib/get_opts.py
@@ -52,5 +52,7 @@ citation_parser = subparsers.add_parser('citation', help='view citation')
 citation_parser.add_argument('dataset', help='dataset name', nargs='?', default=None)
 
 reset_parser = subparsers.add_parser('reset', help='reset retriever: removes configation settings, scripts, and cached data')
+reset_parser.add_argument('scope', help='things to reset: all, scripts, data, or connections',
+                          choices=['all', 'scripts', 'data', 'connections'])
 
 help_parser = subparsers.add_parser('help', help='')

--- a/lib/tools.py
+++ b/lib/tools.py
@@ -10,6 +10,8 @@ import os
 import sys
 import warnings
 import unittest
+import shutil
+import os
 from decimal import Decimal
 from hashlib import md5
 from retriever import HOME_DIR
@@ -264,3 +266,28 @@ def choose_engine(opts, choice=True):
         
     engine.opts = opts
     return engine
+
+def reset_retriever(scope):
+    """Remove stored information on scripts, data, and connections"""
+
+    warning_messages= {'all': "This will remove existing scripts, cached data, and information on database connections. Specifically it will remove the scripts and raw_data folders and the connections.config file in {}. Do you want to proceed? (y/N)\n",
+                       'scripts': "This will remove existing scripts. Specifically it will remove the scripts folder in {}. Do you want to proceed? (y/N)\n",
+                       'data': "This will remove raw data cached by the Retriever. Specifically it will remove the raw_data folder in {}. Do you want to proceed? (y/N)\n",
+                       'connections': "This will remove stored information on database connections. Specifically it will remove the connections.config file in {}. Do you want to proceed? (y/N)\n"
+    }
+
+    warn_msg = warning_messages[scope].format(HOME_DIR)
+    confirm = raw_input(warn_msg)
+    while not (confirm.lower() in ['y', 'n', '']):
+        print("Please enter either y or n.")
+        confirm = raw_input()
+    if confirm.lower() == 'y':
+        if scope in ['data', 'all']:
+            shutil.rmtree(os.path.join(HOME_DIR, 'raw_data'))
+        if scope in ['scripts', 'all']:
+            shutil.rmtree(os.path.join(HOME_DIR, 'scripts'))
+        if scope in ['connections', 'all']:
+            try:
+                os.remove(os.path.join(HOME_DIR, 'connections.config'))
+            except:
+                pass


### PR DESCRIPTION
'retriever reset' now takes an argument controlling the scope of the reset.
This argument can be 'all' to remove all of the cached information or
'scripts', 'data', or 'connections' to only remove the named pieces.

Moves the reset logic into a function in lib/tools to keep it from cluttering up __main__.

Closes #215.