### PR TITLE
Check for and use system proxies for downloading files

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,1 +1,14 @@
+
 """retriever.lib contains the core EcoData Retriever modules."""
+import os
+
+def set_proxy():
+  proxies = ["https_proxy", "http_proxy", "ftp_proxy", "HTTP_PROXY", "HTTPS_PROXY", "FTP_PROXY"]
+  for proxy in proxies:
+    if os.getenv(proxy):
+      if len(os.environ[proxy]) != 0:
+        for i in proxies:
+          os.environ[i] = os.environ[proxy]
+        break
+      
+set_proxy()


### PR DESCRIPTION
In some cases when the user is using a proxy urlib.urlopen() will fail to successfully open https files. This prevents the retriever from accessing the scripts stored on GitHub and causes the installation to fail (see #268). This change checks for the existence of proxies and makes them available in a way that urllib.urlopen() can find them