### PR TITLE
Check input path on download. Fixes #205

### DIFF
--- a/engines/download_only.py
+++ b/engines/download_only.py
@@ -51,7 +51,18 @@ class engine(Engine):
                     print("Keeping existing copy.")
                 else:
                     print("Copying %s from %s" % (file_name_nopath, file_path))
-                    shutil.copy(file_name, self.opts['path'])
+                    if os.path.isdir(self.opts['path']):
+                        try:
+                            shutil.copy(file_name, self.opts['path'])
+                        except:
+                            print("Couldn't copy file to %s" % self.opts['path'])
+                    else:
+                        try:
+                            print("Creating directory %s" % self.opts['path'])
+                            os.mkdir(self.opts['path'])
+                            shutil.copy(file_name, self.opts['path'])
+                        except:
+                            print("Couldn't create directory %s" % self.opts['path'])
         self.all_files = set()
 
     def auto_create_table(self, table, url=None, filename=None, pk=None):


### PR DESCRIPTION
Have a look, is this good enough, or we should add some other checks?
shutil.copy() can fail in two situation:
1- No write access to location
2- File already exists - In this case it already gives a error message saying it's the same file.

So should we catch the exception and prints it, or print our own error string, as I have done in this patch (it's cleaner but the user wouldn't know the failure is due to which of the cases above)?
