### PR TITLE
Do not use bulk insert for DelMoral 2010 species table

### DIFF
--- a/scripts/EA_del_moral_2010.script
+++ b/scripts/EA_del_moral_2010.script
@@ -17,4 +17,5 @@ table: species_plot_year, http://esapubs.org/archive/ecol/E091/152/MSH_SPECIES_P
 table: structure_plot_year, http://esapubs.org/archive/ecol/E091/152/MSH_STRUCTURE_PLOT_YEAR.csv
 table: species, http://esapubs.org/archive/ecol/E091/152/MSH_SPECIES_DESCRIPTORS.csv
 *escape_single_quotes: True
+*do_not_bulk_insert: True
 table: plots, http://esapubs.org/archive/ecol/E091/152/MSH_PLOT_DESCRIPTORS.csv


### PR DESCRIPTION
The species table contains some values in the taxonomy fields with extra
spaces that should be cleaned up.

This caused a test failure in MySQL on Travis (#269) that wasn't seen locally due
to differences in how the systems were configured.