### PR TITLE
add default script directory to dev docs

### DIFF
--- a/apidocs/dev.html
+++ b/apidocs/dev.html
@@ -28,7 +28,8 @@ EcoData Retriever API.</p>
 in the "scripts" directory. Each script contains instructions to access a
 different dataset; if you need a dataset that's not yet supported, you can
 create your own script in the "scripts" directory and it will show up
-automatically.</p>
+automatically.  On Mac and Linux, this directory is in ~/.retriever/scripts
+by default</p>
 <h3>A simple example</h3>
 <p>The EcoData Retriever platform was developed to take the most effort out of
 the most common tasks in importing data. As an example, the Ernest Mammal


### PR DESCRIPTION
BTW, how do users find these docs? I didn't see a way to access it from the command line or from the GUI.