### PR TITLE
Only load a script the first time it is discovered

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -86,8 +86,11 @@ def MODULE_LIST(force_compile=False):
             file, pathname, desc = imp.find_module(script_name, [search_path])
             try:
                 new_module = imp.load_module(script_name, file, pathname, desc)
-                new_module.SCRIPT.download
-                modules.append(new_module)
+                if not new_module in modules:
+                    # if the script wasn't found in an early search path
+                    # make sure it works and then add it
+                    new_module.SCRIPT.download
+                    modules.append(new_module)
             except:
                 sys.stderr.write("Failed to load script: %s (%s)" % (script_name, search_path))
 


### PR DESCRIPTION
When MODULE_LIST() searches for scripts it looks from them in three places:
1. The working directory
2. The the 'scripts' directory in the working directory
3. '~/.retriever/scripts

It is possible for the same script to be present in multiple of these directories.
This is particularly true for developers who have the retriever installed and so
when developing open have copies of all scripts in both the repos scripts directory
and '~/.retriever/scripts'.

This change checks to see if a particular script has already been added to avoid
duplicates. The will prevent developers from getting duplicates in 'retriever ls',
from accidentally producing 'version.txt' with duplicate values (resulting in
duplicate downloads for users), and avoid tricky developer/testing bugs where the
wrong script is being used.

Fixes #316.