### PR TITLE
Improve handling of operating system checks

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,8 +12,8 @@ import imp
 from lib.compile import compile_script
 import platform
 
-current_platform = platform.platform().lower()
-if not "win" in current_platform:
+current_platform = platform.system().lower()
+if current_platform != 'windows':
     import pwd
 
 VERSION = 'v1.7.0'
@@ -30,7 +30,7 @@ for dir in (HOME_DIR, os.path.join(HOME_DIR, 'raw_data'), os.path.join(HOME_DIR,
     if not os.path.exists(dir):
         try:
             os.makedirs(dir)
-            if (not "win" in current_platform) and os.getenv("SUDO_USER"):
+            if (current_platform != 'windows') and os.getenv("SUDO_USER"):
                 # owner of .retriever should be user even when installing w/sudo
                 pw = pwd.getpwnam( os.getenv("SUDO_USER") )
                 os.chown(dir, pw.pw_uid, pw.pw_gid)
@@ -53,7 +53,7 @@ DATA_WRITE_PATH =       DATA_SEARCH_PATHS[-1]
 
 # Create default data directory
 isgui = len(sys.argv) == 1 or ((len(sys.argv) > 1 and sys.argv[1] == 'gui'))
-if "win" in current_platform and isgui:
+if current_platform == 'windows' and isgui:
     # The run path for installer based GUI on Windows is a system path.
     # Users won't expect the data to be stored there, so store it on the Desktop
     DATA_DIR = os.path.join(os.path.expanduser('~'), 'Desktop')

--- a/__main__.py
+++ b/__main__.py
@@ -15,7 +15,7 @@ reload(sys)
 if hasattr(sys, 'setdefaultencoding'):
     # set default encoding to latin-1 to avoid ascii encoding issues
     sys.setdefaultencoding('latin-1')
-from retriever import VERSION, MASTER, SCRIPT_LIST, sample_script
+from retriever import VERSION, MASTER, SCRIPT_LIST, sample_script, current_platform
 from retriever.engines import engine_list
 from retriever.lib.repository import check_for_updates
 from retriever.lib.lists import Category, get_lists
@@ -28,7 +28,7 @@ def main():
     if len(sys.argv) == 1 or (len(sys.argv) > 1 and sys.argv[1] == 'gui'):
         # if no command line args are passed, launch GUI
 
-        check_for_updates(graphical=False if 'darwin' in platform.platform().lower() else True)
+        check_for_updates(graphical=False if current_platform == 'darwin' else True)
         lists = get_lists()
 
         from retriever.app.main import launch_app

--- a/engines/msaccess.py
+++ b/engines/msaccess.py
@@ -1,7 +1,6 @@
 import os
-import platform
 from retriever.lib.models import Engine, no_cleanup
-from retriever import DATA_DIR
+from retriever import DATA_DIR, current_platform
 
 class engine(Engine):
     """Engine instance for Microsoft Access."""
@@ -145,8 +144,7 @@ IN "''' + filepath + '''" "Text;FMT=''' + fmt + ''';HDR=''' + hdr + ''';"'''
 
     def get_connection(self):
         """Gets the db connection."""
-        p = platform.platform().lower()
-        if "darwin" in p or not "win" in p:
+        if current_platform != "windows":
             raise Exception("MS Access can only be used in Windows.")
         import pypyodbc as dbapi
         self.get_input()

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,13 @@ import platform
 import sys
 import warnings
 
-p = platform.platform().lower()
+current_platform = platform.system().lower()
 extra_includes = []
-if "darwin" in p:
+if current_platform == "darwin":
     try: import py2app
     except ImportError: pass
     extra_includes = []
-elif "win" in p:
+elif current_platform == "windows":
     try: import py2exe
     except ImportError: pass
     import sys
@@ -103,7 +103,7 @@ setup(name='retriever',
       # py2app flags
       app=['__main__.py'],
       data_files=[('', ['CITATION'])],
-      setup_requires=['py2app'] if 'darwin' in p else [],
+      setup_requires=['py2app'] if current_platform == 'darwin' else [],
 
       # options
       # optimize is set to 1 of py2app to avoid errors with pymysql


### PR DESCRIPTION
1. Fix cases where OS X was incorrectly identified as Windows
2. Clean up platform checking to minimize duplicated code and be consistent across files