### PR TITLE
Use existing primary key for Portal mammals data

### DIFF
--- a/scripts/EA_portal_mammals.script
+++ b/scripts/EA_portal_mammals.script
@@ -8,8 +8,8 @@ scan_lines: 40000
 table: main, http://esapubs.org/archive/ecol/E090/118/Portal_rodents_19772002.csv
 *delimiter: ','
 *nulls: '', None
-*column: record_id, pk-auto
-*column: recordid, skip
+*contains_pk: True
+*column: recordid, pk-int
 *column: mo, int
 *column: dy, int
 *column: yr, int


### PR DESCRIPTION
This more closely links the installed data with the raw data.

It also addresses an issue that was occuring with csv installs where
the existing primary key title wasn't being skipped appropriately.
See #327.