### PR TITLE
Allow downloading archives without names in urls

### DIFF
--- a/lib/engine.py
+++ b/lib/engine.py
@@ -377,11 +377,15 @@ class Engine():
             file.close()
 
     def download_files_from_archive(self, url, filenames, filetype="zip",
-                                    keep_in_dir=False):
-        """Downloads one or more files from an archive into the raw data
-        directory."""
+                                    keep_in_dir=False, archivename=None):
+        """Downloads files from an archive into the raw data directory.
+
+        """
         downloaded = False
-        archivename = self.format_filename(filename_from_url(url))
+        if archivename:
+            archivename = self.format_filename(archivename)
+        else:
+            archivename = self.format_filename(filename_from_url(url))
 
         if keep_in_dir:
             archivebase = os.path.splitext(os.path.basename(archivename))[0]
@@ -399,7 +403,7 @@ class Engine():
             else:
                 self.create_raw_data_dir()
                 if not downloaded:
-                    self.download_file(url, filename_from_url(url))
+                    self.download_file(url, archivename, clean_line_endings=False)
                     downloaded = True
 
                 if filetype == 'zip':


### PR DESCRIPTION
When using web services to retrieve files the file names are sometimes not included in the url.
The retriever uses urls to create file names for raw data storage and access so this change
adds the ability to add a prefix to the "file name" that is being parsed from the url. In some webservices
this "file name" may just be the last parameter set and so require the prefix to be informative.

To solve this for archives this adds an optional archivename argument to download_files_from_archive
that allows a database script to provide the name for the file to be saved.