### PR TITLE
remove the updating of remaining-time for download. fixes #396

### DIFF
--- a/app/download_manager.py
+++ b/app/download_manager.py
@@ -102,8 +102,9 @@ class DownloadManager:
 
             current_progress = progress(s)
             if current_progress:
-                (keepgoing, skip) = self.dialog.Update(current_progress, s)
-            else:
+            # download progress remaining-time disabled. causes bottle neck on Gentry ref: #396.
+            #     (keepgoing, skip) = self.dialog.Update(current_progress, s)
+            # else:
                 (keepgoing, skip) = self.dialog.Pulse(s)
 
             if not keepgoing:


### PR DESCRIPTION
since the program crashes for some datasets we shall not show the download progress