### PR TITLE
Improve cleaning of column names

### DIFF
--- a/lib/table.py
+++ b/lib/table.py
@@ -13,6 +13,7 @@ class Table:
         self.header_rows = 1
         self.column_names_row = 1
         self.fixed_width = False
+        self.cleaned_columns = False
         self.cleanup = Cleanup()
         self.record_id = 0
         self.columns = []
@@ -38,6 +39,7 @@ class Table:
             column_names = [name.strip() for name in values]
 
         columns = map(lambda x: self.clean_column_name(x), column_names)
+        self.cleaned_columns = True
         column_values = {x:[] for x in columns if x}
 
         return [[x, None] for x in columns if x], column_values
@@ -129,6 +131,11 @@ class Table:
     def get_insert_columns(self, join=True):
         """Gets a set of column names for insert statements."""
         columns = ""
+        if not self.cleaned_columns:
+            column_names = list(self.columns)
+            self.columns[:] = []
+            self.columns = [(self.clean_column_name(name[0]), name[1]) for name in column_names]
+            self.cleaned_columns = True
         for item in self.columns:
             thistype = item[1][0]
             if ((thistype != "skip") and (thistype !="combine") and

--- a/test/test_regression_cli.py
+++ b/test/test_regression_cli.py
@@ -7,7 +7,7 @@ from hashlib import md5
 known_md5s = {
 
             'sqlite': {'AvianBodySize' : '72256f681cdce96eba32d4ece270bcb2',
-                     'DelMoral2010' : '92b6cd535f8e6c82d6fc19802d6ba64f',
+                     'DelMoral2010' : '2f936afb990c8f818223b27e1e8d6212',
                      'MoM2003' : 'd3bdce86e0fc5888449884dfb0ef4611'},
             
             'download': {'AvianBodySize' : 'dce81ee0f040295cd14c857c18cc3f7e',
@@ -15,7 +15,7 @@ known_md5s = {
                      'MoM2003' : 'b54b80d0d1959bdea0bb8a59b70fa871'},                          
             
             'csv': {'AvianBodySize' : 'f42702a53e7d99d16e909676f30e5aa8',
-                  'DelMoral2010' : '606f97c3ddbfd6d63b474bc76d01646a',
+                  'DelMoral2010' : 'e79d55ac15f1a70a6c7d3ad4e678ec0e',
                   'MoM2003' : 'ef0a31c132cfe1c6594739c872f70f54'},
             
             'mysql': {'AvianBodySize' : 'f60ac93d9be4671dbef77da9d10676b8',
@@ -23,7 +23,7 @@ known_md5s = {
                     'MoM2003' : '9728728d72af4c21a2a6e29fec3edb48'},
             
             'postgres': {'AvianBodySize' : '60c252af74d914e3c15fa9af43edefca',
-                     'DelMoral2010' : '1e8de8fa3ddbd4ca3a7cab921926e70e',
+                     'DelMoral2010' : '63d91a972b5ca07bf90900a576286a8a',
                      'MoM2003' : 'a55c8308722c8e20950e0d1e6d9639e6'}
              }
 


### PR DESCRIPTION
1. Replaces additional SQL keywords
2. Only replaces keywords when they are the entire column name
3. Strips extra whitespace from column names
4. Replaces additional special characters

Combines work by @panks and @henrykironde.