### PR TITLE
Check if a file to be downloaded already exists the destination location

### DIFF
--- a/engines/download_only.py
+++ b/engines/download_only.py
@@ -48,14 +48,17 @@ class engine(Engine):
         if hasattr(self, "all_files"):
             for file_name in self.all_files:
                 file_path, file_name_nopath = os.path.split(file_name)
+                full_path = os.path.join(self.opts['path'], file_name_nopath)
                 subdir = os.path.split(file_path)[1] if self.opts['subdir'] else ''
                 dest_path = os.path.join(self.opts['path'], subdir)
                 if os.path.abspath(file_path) == os.path.abspath(os.path.join(DATA_DIR, subdir)):
                     print ("%s is already in the working directory" % file_name_nopath)
                     print("Keeping existing copy.")
+                elif os.path.exists(full_path):
+                    print ("File already exists at specified location")
                 else:
-                    print("Copying %s from %s" % (file_name_nopath, file_path))
                     if os.path.isdir(dest_path):
+                        print("Copying %s from %s" % (file_name_nopath, file_path))
                         try:
                             shutil.copy(file_name, dest_path)
                         except:
@@ -64,6 +67,7 @@ class engine(Engine):
                         try:
                             print("Creating directory %s" % dest_path)
                             os.makedirs(dest_path)
+                            print("Copying %s from %s" % (file_name_nopath, file_path))
                             shutil.copy(file_name, dest_path)
                         except:
                             print("Couldn't create directory %s" % dest_path)
@@ -122,3 +126,4 @@ for name, method in methods:
         setattr(engine, name, dummy_method)
 for name in remove_methods:
     setattr(engine, name, dummy_method)
+

--- a/test/test_regression_cli.py
+++ b/test/test_regression_cli.py
@@ -1,7 +1,9 @@
 import os
+import shutil
 import nose
 from unittest import TestCase
 from hashlib import md5
+from glob import glob
 
 # First md5 is for csv, second md5 is for sqlite
 known_md5s = {
@@ -31,11 +33,13 @@ known_md5s = {
 def setup_module():
     """Update retriever scripts and cd to test directory to find data"""
     os.chdir("./test/")
+    os.mkdir("downloaddir")
     os.system("retriever update")
 
 def teardown_module():
     """Cleanup temporary output files after testing and return to root directory"""
     os.system("rm output_*")
+    shutil.rmtree("downloaddir")
     os.chdir("..")
 
 def getmd5(filename):
@@ -120,8 +124,9 @@ class PostgreSQLRegression(TestCase):
 class DownloadRegression(TestCase):
     def check_download_regression(self, dataset, known_md5):
         """Check for regression for a particular dataset downloaded only"""
-        os.system("retriever download {0} -p raw_data/{0}".format(dataset))
-        current_md5 = getmd5dir("raw_data/%s" %(dataset))
+        os.system("rm downloaddir/*")
+        os.system("retriever download {0} -p downloaddir".format(dataset))
+        current_md5 = getmd5dir("downloaddir")
         assert current_md5 == known_md5
 
 


### PR DESCRIPTION
When using the `download` engine and installing the data somewhere other than the working directory,
the retriever didn't check to see if the file was already there. This change checks the destination and
if the file is already there it does not download/move the file and reports that it already exists.

This also required changing the `download` engines regression tests so that they were still testing
the main behavior of the code.