### PR TITLE
add py.test and remove nose test fixes #404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,14 @@ install:
   - pip install -r requirements.txt --use-mirrors
   - python setup.py -q install
   - pip install codecov
-  - pip install nose-cov
+  - pip install pytest-cov
+  - pip install pytest-xdist      
+
 
 # command to run tests
-script: nosetests --with-cov
+
+script:
+  - py.test --cov=retriever 
 
 # database setup
 before_script:


### PR DESCRIPTION
no environment variables explicitly set (tox.ini). [ref](https://github.com/codecov/example-python)