### PR TITLE
Add integration testing

### DIFF
--- a/engines/csv.py
+++ b/engines/csv.py
@@ -45,6 +45,10 @@ class engine(Engine):
         self.output_file = open(self.table_name(), "w")
         self.output_file.write(','.join(['"%s"' % c[0] for c in self.table.columns]))
 
+    def disconnect(self):
+        """Close the last file"""
+        self.output_file.close()
+
     def execute(self, statement, commit=True):
         """Write a line to the output file"""
         self.output_file.write('\n' + statement)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -16,17 +16,17 @@ crosstab = {'name': 'crosstab',
             'script': "shortname: crosstab\ntable: crosstab, http://example.com/crosstab.txt\n*column: a, int\n*column: b, int\n*ct_column: c\n*column: val, ct-double\n*ct_names: c1,c2",
             'expect_out': "a,b,c,val\n1,1,c1,1.1\n1,1,c2,1.2\n1,2,c1,2.1\n1,2,c2,2.2"}
 
-tests = [simple_csv, crosstab]
+tests = [simple_csv]
 
 def setup_module():
     """Put raw data and scripts in appropriate .retriever directories"""
     for test in tests:
         if not os.path.exists(os.path.join(HOME_DIR, "raw_data", test['name'])):
             os.makedirs(os.path.join(HOME_DIR, "raw_data", test['name']))
-        data_file = open(os.path.join(HOME_DIR, "raw_data", test['name'], test['name'] + '.txt'), 'w')
-        script_file = open(os.path.join(HOME_DIR, "scripts", test['name'] + '.script'), 'w')
-        data_file.write(test['raw_data'])
-        script_file.write(test['script'])
+        with open(os.path.join(HOME_DIR, "raw_data", test['name'], test['name'] + '.txt'), 'w') as data_file:
+            data_file.write(test['raw_data'])
+        with open(os.path.join(HOME_DIR, "scripts", test['name'] + '.script'), 'w') as script_file:
+            script_file.write(test['script'])
         compile_script(os.path.join(HOME_DIR, "scripts", test['name']))
 
 def teardown_module():

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -13,7 +13,7 @@ simple_csv = {'name': 'simple_csv',
 
 crosstab = {'name': 'crosstab',
             'raw_data': "a,b,c1,c2\n1,1,1.1,1.2\n1,2,2.1,2.2",
-            'script': "shortname: crosstab\ntable: crosstab, http://example.com/crosstab.txt\n*column: a, int\n*column: b, int\n*ct_column: c\n*column: val, ct-double\n*ct_names: c1,c2",
+            'script': "shortname: crosstab\ntable: crosstab, http://example.com/crosstab.txt\n*column: record_id, pk-auto\n*column: a, int\n*column: b, int\n*ct_column: c\n*column: val, ct-double\n*ct_names: c1,c2",
             'expect_out': "a,b,c,val\n1,1,c1,1.1\n1,1,c2,1.2\n1,2,c1,2.1\n1,2,c2,2.2"}
 
 tests = [simple_csv]

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -16,7 +16,7 @@ crosstab = {'name': 'crosstab',
             'script': "shortname: crosstab\ntable: crosstab, http://example.com/crosstab.txt\n*column: record_id, pk-auto\n*column: a, int\n*column: b, int\n*ct_column: c\n*column: val, ct-double\n*ct_names: c1,c2",
             'expect_out': '"record_id","a","b","c","val"\n3,1,1,"c1",1.1\n4,1,1,"c2",1.2\n5,1,2,"c1",2.1\n6,1,2,"c2",2.2'}
 
-tests = [simple_csv]
+tests = [simple_csv, crosstab]
 
 def setup_module():
     """Put raw data and scripts in appropriate .retriever directories"""
@@ -51,3 +51,12 @@ def test_csv_from_csv():
         obs_out = obs_out_file.read()
     print len(obs_out)
     assert obs_out == simple_csv['expect_out']
+
+def test_crosstab_from_csv():
+    crosstab_module = get_script_module('crosstab')
+    crosstab_module.SCRIPT.download(csv_engine)
+    crosstab_module.SCRIPT.engine.disconnect()
+    with open("crosstab_crosstab.txt", 'r') as obs_out_file:
+        obs_out = obs_out_file.read()
+    print len(obs_out)
+    assert obs_out == crosstab['expect_out']

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -3,7 +3,7 @@
 import os
 import shutil
 from retriever.lib.compile import compile_script
-from retriever import HOME_DIR
+from retriever import HOME_DIR, ENGINE_LIST
 
 simple_csv = {'name': 'simple_csv',
               'raw_data': "a,b,c\n1,2,3\n4,5,6",
@@ -33,3 +33,6 @@ def teardown_module():
     for test in tests:
         shutil.rmtree(os.path.join(HOME_DIR, "raw_data", test['name']))
         os.remove(os.path.join(HOME_DIR, "scripts", test['name'] + '.script'))
+
+mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, csv_engine, download_engine = ENGINE_LIST()
+csv_engine.opts = {'engine': 'csv', 'table_name': './{db}_{table}.csv'}

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -15,3 +15,19 @@ crosstab = {'name': 'crosstab',
             'expect_out': "a,b,c,val\n1,1,c1,1.1\n1,1,c2,1.2\n1,2,c1,2.1\n1,2,c2,2.2"}
 
 tests = [simple_csv, crosstab]
+
+def setup_module():
+    """Put raw data and scripts in appropriate .retriever directories"""
+    for test in tests:
+        if not os.path.exists(os.path.join(HOME_DIR, "raw_data", test['name'])):
+            os.makedirs(os.path.join(HOME_DIR, "raw_data", test['name']))
+        data_file = open(os.path.join(HOME_DIR, "raw_data", test['name'], test['name'] + '.txt'), 'w')
+        script_file = open(os.path.join(HOME_DIR, "scripts", test['name'] + '.script'), 'w')
+        data_file.write(test['raw_data'])
+        script_file.write(test['script'])
+
+def teardown_module():
+    """Remove test data and scripts from .retriever directories"""
+    for test in tests:
+        shutil.rmtree(os.path.join(HOME_DIR, "raw_data", test['name']))
+        os.remove(os.path.join(HOME_DIR, "scripts", test['name'] + '.script'))

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -7,9 +7,9 @@ from retriever.lib.compile import compile_script
 from retriever import HOME_DIR, ENGINE_LIST
 
 simple_csv = {'name': 'simple_csv',
-              'raw_data': "a,b,c\n1,2,3\n4,5,6",
+              'raw_data': "a,b,c\n1,2,3\n4,5,6\n",
               'script': "shortname: simple_csv\ntable: simple_csv, http://example.com/simple_csv.txt",
-              'expect_out': "a,b,c\n1,2,3\n4,5,6"}
+              'expect_out': '"record_id","a","b","c"\n1,1,2,3\n2,4,5,6'}
 
 crosstab = {'name': 'crosstab',
             'raw_data': "a,b,c1,c2\n1,1,1.1,1.2\n1,2,2.1,2.2",
@@ -41,8 +41,13 @@ def get_script_module(script_name):
     return imp.load_module(script_name, file, pathname, desc)
 
 mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, csv_engine, download_engine = ENGINE_LIST()
-csv_engine.opts = {'engine': 'csv', 'table_name': './{db}_{table}.csv'}
+csv_engine.opts = {'engine': 'csv', 'table_name': './{db}_{table}.txt'}
 
 def test_csv_from_csv():
     simple_csv_module = get_script_module('simple_csv')
     simple_csv_module.SCRIPT.download(csv_engine)
+    simple_csv_module.SCRIPT.engine.disconnect()
+    with open("simple_csv_simple_csv.txt", 'r') as obs_out_file:
+        obs_out = obs_out_file.read()
+    print len(obs_out)
+    assert obs_out == simple_csv['expect_out']

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,0 +1,17 @@
+"""Integrations tests for EcoData Retriever"""
+
+import os
+import shutil
+from retriever import HOME_DIR
+
+simple_csv = {'name': 'simple_csv',
+              'raw_data': "a,b,c\n1,2,3\n4,5,6",
+              'script': "shortname: simple_csv\ntable: simple_csv, http://example.com/simple_csv.txt",
+              'expect_out': "a,b,c\n1,2,3\n4,5,6"}
+
+crosstab = {'name': 'crosstab',
+            'raw_data': "a,b,c1,c2\n1,1,1.1,1.2\n1,2,2.1,2.2",
+            'script': "shortname: crosstab\ntable: crosstab, http://example.com/crosstab.txt\n*column: a, int\n*column: b, int\n*ct_column: c\n*column: val, ct-double\n*ct_names: c1,c2",
+            'expect_out': "a,b,c,val\n1,1,c1,1.1\n1,1,c2,1.2\n1,2,c1,2.1\n1,2,c2,2.2"}
+
+tests = [simple_csv, crosstab]

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+from retriever.lib.compile import compile_script
 from retriever import HOME_DIR
 
 simple_csv = {'name': 'simple_csv',
@@ -25,6 +26,7 @@ def setup_module():
         script_file = open(os.path.join(HOME_DIR, "scripts", test['name'] + '.script'), 'w')
         data_file.write(test['raw_data'])
         script_file.write(test['script'])
+        compile_script(os.path.join(HOME_DIR, "scripts", test['name']))
 
 def teardown_module():
     """Remove test data and scripts from .retriever directories"""

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,5 +1,6 @@
 """Integrations tests for EcoData Retriever"""
 
+import imp
 import os
 import shutil
 from retriever.lib.compile import compile_script
@@ -34,5 +35,14 @@ def teardown_module():
         shutil.rmtree(os.path.join(HOME_DIR, "raw_data", test['name']))
         os.remove(os.path.join(HOME_DIR, "scripts", test['name'] + '.script'))
 
+def get_script_module(script_name):
+    """Load a script module"""
+    file, pathname, desc = imp.find_module(script_name, [os.path.join(HOME_DIR, "scripts")])
+    return imp.load_module(script_name, file, pathname, desc)
+
 mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, csv_engine, download_engine = ENGINE_LIST()
 csv_engine.opts = {'engine': 'csv', 'table_name': './{db}_{table}.csv'}
+
+def test_csv_from_csv():
+    simple_csv_module = get_script_module('simple_csv')
+    simple_csv_module.SCRIPT.download(csv_engine)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -14,7 +14,7 @@ simple_csv = {'name': 'simple_csv',
 crosstab = {'name': 'crosstab',
             'raw_data': "a,b,c1,c2\n1,1,1.1,1.2\n1,2,2.1,2.2",
             'script': "shortname: crosstab\ntable: crosstab, http://example.com/crosstab.txt\n*column: record_id, pk-auto\n*column: a, int\n*column: b, int\n*ct_column: c\n*column: val, ct-double\n*ct_names: c1,c2",
-            'expect_out': "a,b,c,val\n1,1,c1,1.1\n1,1,c2,1.2\n1,2,c1,2.1\n1,2,c2,2.2"}
+            'expect_out': '"record_id","a","b","c","val"\n3,1,1,"c1",1.1\n4,1,1,"c2",1.2\n5,1,2,"c1",2.1\n6,1,2,"c2",2.2'}
 
 tests = [simple_csv]
 


### PR DESCRIPTION
Adds an initial draft of an integration testing system that is based on small example scripts, data,
and expected output. Expected output is given in the form of a csv file. The current system only
handles the csv engine. Expansion to further engines should be based on having those engines output
an identically formatted csv file.