### PR TITLE
minor error message fix

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -129,7 +129,7 @@ def main():
             print "Done!"
         else:
             print "The dataset {} isn't currently available in the Retriever".format(args.dataset)
-            print "Run 'retriever -ls to see a list of currently available datasets"
+            print "Run 'retriever ls to see a list of currently available datasets"
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
in the error message about `The dataset * isn't currently available in the Retriever` the message should propose `retriever ls` not `retriever -ls` (i.e. `l` and `s` aren't flags)