### PR TITLE
Remove extra `disconnect` method from csv engine

### DIFF
--- a/engines/csv.py
+++ b/engines/csv.py
@@ -62,10 +62,6 @@ class engine(Engine):
             # fine so just pass
             pass
 
-    def disconnect(self):
-        """Close the last file"""
-        self.output_file.close()
-
     def execute(self, statement, commit=True):
         """Write a line to the output file"""
         self.output_file.write('\n' + statement)


### PR DESCRIPTION
Due to merging in some code that had originally been branched almost a
year ago, we ended up with an extra `disconnect` method.

Originally caught by @henrykironde.