### PR TITLE
add execution for setting auto-comit off when bulk insert

### DIFF
--- a/engines/postgres.py
+++ b/engines/postgres.py
@@ -1,5 +1,5 @@
 import os
-import platform
+
 from retriever.lib.models import Engine, no_cleanup
 
 
@@ -72,11 +72,10 @@ class engine(Engine):
         self.get_cursor()
         ct = len([True for c in self.table.columns if c[1][0][:3] == "ct-"]) != 0
         if (([self.table.cleanup.function, self.table.delimiter,
-             self.table.header_rows] == [no_cleanup, ",", 1])
+              self.table.header_rows] == [no_cleanup, ",", 1])
             and not self.table.fixed_width
             and not ct
-            and (not hasattr(self.table, "do_not_bulk_insert") or not self.table.do_not_bulk_insert)
-            ):
+            and (not hasattr(self.table, "do_not_bulk_insert") or not self.table.do_not_bulk_insert)):
             columns = self.table.get_insert_columns()
             filename = os.path.abspath(filename)
             statement = """
@@ -85,7 +84,9 @@ FROM '""" + filename.replace("\\", "\\\\") + """'
 WITH DELIMITER ','
 CSV HEADER"""
             try:
+                self.execute("BEGIN")
                 self.execute(statement)
+                self.execute("COMMIT")
             except:
                 self.connection.rollback()
                 return Engine.insert_data_from_file(self, filename)


### PR DESCRIPTION
add execution for setting auto-comit off when bulk insert
remove print exception when bulk insert fails for mysql

To improve the likely hood of bulk insert for mysql and postgres

mysql configuration
===================

set off some of the parameters (mysql_set_autocommit_off)
SET autocommit=0;
SET UNIQUE_CHECKS=0;
SET FOREIGN_KEY_CHECKS=0;
SET sql_log_bin=0;

Once the bulk has been  has been executed
we set the configurations back (mysql_set_autocommit_on)

Postgres
========

BEGIN initiates a transaction block and all statements after a BEGIN command will be executed
in a single transaction until an explicit COMMIT or ROLLBACK is given.

self.execute("BEGIN")
self.execute(statement)
self.execute("COMMIT")