### PR TITLE
Adjust number of header rows in BBS 50 Stop species table

### DIFF
--- a/scripts/bbs50stop.py
+++ b/scripts/bbs50stop.py
@@ -37,7 +37,7 @@ class main(Script):
 
             # Species table
             table = Table("species", cleanup=Cleanup(), contains_pk=True,
-                          header_rows=6)
+                          header_rows=9)
 
             table.columns=[("species_id", ("pk-int",) ),
                            ("AOU", ("int",) ),


### PR DESCRIPTION
Changes number of header rows to match new data structure.

Mirrors fc8c143f95fa690365637fa628bda1fa61d39fc7 for bbs50stop.