### PR TITLE
Print exception message if script not loaded on installation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -94,8 +94,8 @@ def MODULE_LIST(force_compile=False):
                     # make sure it works and then add it
                     new_module.SCRIPT.download
                     modules.append(new_module)
-            except:
-                sys.stderr.write("Failed to load script: %s (%s)" % (script_name, search_path))
+            except Exception as e:
+                sys.stderr.write("Failed to load script: %s (%s)\nException: %s \n" % (script_name, search_path, str(e)) )
 
     return modules
 


### PR DESCRIPTION
Prints description of error when `__init__.py` fails to compile script