### PR TITLE
Issue 290: Out of memory error when downloading large dataset

### DIFF
--- a/lib/templates.py
+++ b/lib/templates.py
@@ -117,9 +117,10 @@ class DownloadOnlyTemplate(Script):
     def download(self, engine=None, debug=False):
         if engine.name != "Download Only":
             raise Exception("This dataset contains only non-tabular data files, and can only be used with the 'download only' engine.\nTry 'retriever download datasetname instead.")
-        Script.download(self, engine, debug)
-        for filename, url in list(self.urls.items()):
-            self.engine.download_file(url, filename, clean_line_endings=False)
+        Script.download(self, engine, debug) 
+
+        for filename, url in self.urls.items():
+            self.engine.download_file(url, filename)
             if os.path.exists(self.engine.format_filename(filename)):
                 shutil.copy(self.engine.format_filename(filename), DATA_DIR)
             else:

--- a/scripts/gentry.py
+++ b/scripts/gentry.py
@@ -56,7 +56,7 @@ U.S.A. """
         # Currently all_Excel.zip is missing CURUYUQU.xls
         # Download it separately and add it to the file list
         if not self.engine.find_file('CURUYUQU.xls'):
-            self.engine.download_file("http://www.mobot.org/mobot/gentry/123/samerica/CURUYUQU.xls", "CURUYUQU.xls", clean_line_endings=False)
+            self.engine.download_file("http://www.mobot.org/mobot/gentry/123/samerica/CURUYUQU.xls", "CURUYUQU.xls")
             filelist.append('CURUYUQU.xls')
 
         lines = []


### PR DESCRIPTION
I've removed the part where the entire file is being read into memory to clean line endings and have opened the file in 'rU' mode instead.

However, the tests for md5 comparisons for csv, mysql and postgres are all failing with this change.