### PR TITLE
Extends the lenght of muliple text fields in AmnioteDB

### DIFF
--- a/scripts/AmnioteLH.script
+++ b/scripts/AmnioteLH.script
@@ -9,12 +9,12 @@ table: main, http://esapubs.org/archive/ecol/E096/269/Data_Files/Amniote_Databas
 *delimiter: ','
 *column: record_id, pk-auto
 *column: class, char, 20
-*column: order, char, 20	
+*column: order, char, 20
 *column: family, char, 20
-*column: genus, char, 20	
-*column: species, char, 20	
-*column: subspecies, char, 20	
-*column: common_name, char, 40	
+*column: genus, char, 20
+*column: species, char, 50
+*column: subspecies, char, 20
+*column: common_name, char, 400
 *column: trait_value, ct-double
 *ct_column: trait
 *ct_names: female_maturity_d, litter_or_clutch_size_n, litters_or_clutches_per_y, adult_body_mass_g, maximum_longevity_y, gestation_d, weaning_d, birth_or_hatching_weight_g, weaning_weight_g, egg_mass_g, incubation_d, fledging_age_d, longevity_y, male_maturity_d, inter_litter_or_interbirth_interval_y, female_body_mass_g, male_body_mass_g, no_sex_body_mass_g, egg_width_mm, egg_length_mm, fledging_mass_g, adult_svl_cm, male_svl_cm, female_svl_cm, birth_or_hatching_svl_cm, female_svl_at_maturity_cm, female_body_mass_at_maturity_g, no_sex_svl_cm, no_sex_maturity_d


### PR DESCRIPTION
The maximum lengths on these text fields were shorter than the data. In the
case of the common name field their are a couple of particular long (and somewhat
odd) common names.

Fixes #505.