### PR TITLE
Extend length of ct_column to 50

### DIFF
--- a/lib/engine.py
+++ b/lib/engine.py
@@ -177,7 +177,7 @@ class Engine():
             self.auto_get_datatypes(pk, lines, columns, column_values)
 
         if self.table.columns[-1][1][0][:3] == "ct-" and hasattr(self.table, "ct_names") and not self.table.ct_column in [c[0] for c in self.table.columns]:
-            self.table.columns = self.table.columns[:-1] + [(self.table.ct_column, ("char", 20))] + [self.table.columns[-1]]
+            self.table.columns = self.table.columns[:-1] + [(self.table.ct_column, ("char", 50))] + [self.table.columns[-1]]
 
         self.create_table()
 


### PR DESCRIPTION
The ct_column column was being set to be a character column of max length 20.
This turned out to be too short in some cases so this extends it to 50.

Fixes #505.