### PR TITLE
Include `future` module in installation and packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 import warnings
 
 current_platform = platform.system().lower()
-extra_includes = ['future']
+extra_includes = []
 if current_platform == "darwin":
     try:
         import py2app
@@ -42,6 +42,7 @@ packages = [
 
 includes = [
     'xlrd',
+    'future'
     'pymysql',
     'psycopg2',
     'sqlite3',
@@ -84,6 +85,7 @@ setup(name='retriever',
       },
       install_requires=[
           'xlrd',
+          'future'
       ],
 
       # py2exe flags


### PR DESCRIPTION
Having added `future` for Python 2/3 compatibility we need to automatically
install it when installing via pip and when packaging the retriever.

It had been added to `extra_includes` but in a way that only got included on
Linux. This moves it to `includes` where it will always get included in the
binary packages and adds it to `install_requires` where it will get picked up
when installing via `pip`.