### PR TITLE
Update location and details of Portal supplemental tables

### DIFF
--- a/scripts/EA_portal_mammals.script
+++ b/scripts/EA_portal_mammals.script
@@ -40,13 +40,6 @@ table: main, http://esapubs.org/archive/ecol/E090/118/Portal_rodents_19772002.cs
 *column: note4, char, 9
 *column: note5, char, 9
 
-table: species, http://wiki.ecologicaldata.org/sites/default/files/portal_species.txt
+table: species, https://ndownloader.figshare.com/files/3299483
 
-table: plots, http://wiki.ecologicaldata.org/sites/default/files/portal_plots.txt
-*delimiter: ','
-*contains_pk: True
-*header_rows: 0
-*column: PlotID, pk-int
-*column: PlotTypeAlphaCode, char, 2
-*column: PlotTypeNumCode, int
-*column: PlotTypeDescript, char, 30
+table: plots, https://ndownloader.figshare.com/files/3299474


### PR DESCRIPTION
The supplemental tables (species and plots) for the Portal database aren't
available as part of the core dataset, so they had been stored on the old
Ecological Data Wiki server. We failed to move them in the update of the
data wiki so those links are now failing. I've updated the script to use
the tables in the Portal Project Teaching Database on Figshare, which will
be a more stable location until we update to the newest Portal release.