### PR TITLE
Unicode changes for python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ sudo: false
 language: python
 python:
   - "2.7"
+  - "3.5"
 addons:
-  postgresql: "9.2"
+  postgresql: "9.4"
 
 services:
   - postgresql
 install:
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
   - python setup.py -q install
   - pip install codecov
   - pip install pytest-cov

--- a/__main__.py
+++ b/__main__.py
@@ -16,7 +16,7 @@ import sys
 # sys removes the setdefaultencoding method at startup; reload to get it back
 reload(sys)
 if hasattr(sys, 'setdefaultencoding'):
-    # set default encoding to latin-1 to avoid ascii encoding issues
+    # set default encoding to utf-8 to avoid ascii encoding issues
     sys.setdefaultencoding('utf-8')
 from retriever import VERSION, MASTER, SCRIPT_LIST, sample_script, current_platform
 from retriever.engines import engine_list

--- a/__main__.py
+++ b/__main__.py
@@ -17,7 +17,7 @@ import sys
 reload(sys)
 if hasattr(sys, 'setdefaultencoding'):
     # set default encoding to latin-1 to avoid ascii encoding issues
-    sys.setdefaultencoding('latin-1')
+    sys.setdefaultencoding('utf-8')
 from retriever import VERSION, MASTER, SCRIPT_LIST, sample_script, current_platform
 from retriever.engines import engine_list
 from retriever.lib.repository import check_for_updates

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,10 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+
   # postgres
   POSTGRES_PORT: tcp://localhost:5432
   POSTGRES_ENV_POSTGRES_USER: postgres

--- a/engines/postgres.py
+++ b/engines/postgres.py
@@ -1,5 +1,5 @@
 import os
-
+from builtins import str
 from retriever.lib.models import Engine, no_cleanup
 
 
@@ -96,8 +96,6 @@ CSV HEADER"""
     def insert_statement(self, values):
         """Returns a SQL statement to insert a set of values"""
         statement = Engine.insert_statement(self, values)
-        if isinstance(statement, basestring):
-            statement = statement.decode("utf-8", "ignore")
         return statement
 
     def table_exists(self, dbname, tablename):

--- a/engines/postgres.py
+++ b/engines/postgres.py
@@ -96,6 +96,8 @@ CSV HEADER"""
     def insert_statement(self, values):
         """Returns a SQL statement to insert a set of values"""
         statement = Engine.insert_statement(self, values)
+        if isinstance(statement, bytes):
+            statement = statement.decode("utf-8", "ignore")
         return statement
 
     def table_exists(self, dbname, tablename):

--- a/lib/compile.py
+++ b/lib/compile.py
@@ -25,7 +25,7 @@ def compile_script(script_file):
     keys_to_ignore = ["template"]
 
     for line in [line.strip() for line in definition]:
-        if line != "" and ':' in line and not line[0] == '#':
+        if line and ':' in line and not line[0] == '#':
             split_line = [a.strip() for a in line.split(":")]
             key = split_line[0].lower()
             value = ':'.join(split_line[1:])

--- a/lib/compile.py
+++ b/lib/compile.py
@@ -15,7 +15,7 @@ SCRIPT = HtmlTableTemplate(%s)""",
 
 
 def compile_script(script_file):
-    definition = open(script_file + ".script", 'rb')
+    definition = open(script_file + ".script", 'r')
 
     values = {}
     urls = {}
@@ -25,7 +25,7 @@ def compile_script(script_file):
     keys_to_ignore = ["template"]
 
     for line in [line.strip() for line in definition]:
-        if line and ':' in line and not line[0] == '#':
+        if line != "" and ':' in line and not line[0] == '#':
             split_line = [a.strip() for a in line.split(":")]
             key = split_line[0].lower()
             value = ':'.join(split_line[1:])
@@ -134,7 +134,7 @@ def compile_script(script_file):
         template = "default"
     script_contents = (script_templates[template] % script_desc)
 
-    new_script = open(script_file + '.py', 'wb')
+    new_script = open(script_file + '.py', 'w')
     new_script.write(script_contents)
     new_script.close()
 

--- a/lib/engine.py
+++ b/lib/engine.py
@@ -277,12 +277,12 @@ class Engine(object):
             thistype = self.datatypes[thistype]
 
             if isinstance(thistype, tuple):
-                if len(datatype) > 1 and datatype[1] > 0:
+                if len(datatype) > 1 and int(datatype[1]) > 0:
                     thistype = thistype[1] + "(" + str(datatype[1]) + ")"
                 else:
                     thistype = thistype[0]
             else:
-                if len(datatype) > 1 and datatype[1] > 0:
+                if len(datatype) > 1 and int(datatype[1]) > 0:
                     thistype += "(" + str(datatype[1]) + ")"
         else:
             thistype = ""
@@ -393,7 +393,7 @@ class Engine(object):
             self.create_raw_data_dir()
             print("Downloading " + filename + "...")
             response = urllib.request.urlretrieve(url, path)
-            
+
 
     def download_files_from_archive(self, url, filenames, filetype="zip",
                                     keep_in_dir=False, archivename=None):
@@ -438,7 +438,7 @@ class Engine(object):
                 fileloc = self.format_filename(os.path.join(archivebase,
                                                             os.path.basename(filename)))
 
-                unzipped_file = open(fileloc, 'wb')
+                unzipped_file = open(fileloc, 'w')
                 for line in open_archive_file:
                     unzipped_file.write(line)
                 open_archive_file.close()
@@ -477,8 +477,8 @@ class Engine(object):
         # due to Cyclic imports we can not move this import to the top
         from retriever.lib.tools import sort_csv
         csvfile_output = (self.table_name() + '.csv')
-        csv_out = open(csvfile_output, "wb")
-        csv_writer = csv.writer(csv_out, dialect='excel')
+        csv_out = open(csvfile_output, "w")
+        csv_writer = csv.writer(csv_out, dialect='excel', lineterminator='\n')
         self.get_cursor()
         self.cursor.execute("SELECT * FROM " + self.table_name() + ";")
         row = self.cursor.fetchone()
@@ -682,7 +682,7 @@ def filename_from_url(url):
 def gen_from_source(source):
     """Returns a generator from a source tuple.
     Source tuples are of the form (callable, args) where callable(*args)
-    returns either a generator or another source tuple. 
+    returns either a generator or another source tuple.
     This allows indefinite regeneration of data sources.
     """
     while isinstance(source, tuple):

--- a/lib/excel.py
+++ b/lib/excel.py
@@ -23,5 +23,5 @@ class Excel(object):
     def cell_value(cell):
         """Returns the string value of an excel spreadsheet cell"""
         if (cell.value).__class__.__name__ == 'unicode':
-            return (cell.value).encode('utf-8').strip()
+            return (cell.value).encode().strip()
         return str(cell.value).strip()

--- a/lib/repository.py
+++ b/lib/repository.py
@@ -101,7 +101,7 @@ class InitThread(Thread):
             scripts = []
             print("Downloading scripts...")
             for line in version_file:
-                scripts.append(line.strip('\n').split(','))
+                scripts.append(line.decode().strip('\n').split(','))
 
             total_script_count = len(scripts)
 

--- a/lib/table.py
+++ b/lib/table.py
@@ -2,8 +2,10 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import next
 from builtins import object
+from builtins import str
 import csv
 import io
+import sys
 from functools import reduce
 
 from retriever.lib.cleanup import *
@@ -110,7 +112,11 @@ class Table(object):
         """Combine a list of values into a line of csv data"""
         dialect = csv.excel
         dialect.escapechar = "\\"
-        writer_file =  io.BytesIO()
+        if sys.version_info >= (3, 0):
+            writer_file =  io.StringIO()
+        else:
+            writer_file =  io.BytesIO()
+
         writer = csv.writer(writer_file, dialect=dialect, delimiter=self.delimiter)
         writer.writerow(line_as_list)
         return writer_file.getvalue()

--- a/lib/tools.py
+++ b/lib/tools.py
@@ -281,7 +281,6 @@ def xml2csv(input_file, outputfile=None, header_values=None, row_tag="row"):
 def getmd5(data, data_type='lines', mode='rb'):
     """Get MD5 of a data source"""
     checksum = md5()
-    # mode = 'rb'
     if data_type == 'lines':
         for line in data:
             if type(line) == bytes:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,6 +1,5 @@
 """Integrations tests for EcoData Retriever"""
 from __future__ import print_function
-
 import imp
 import os
 import shutil

--- a/version.py
+++ b/version.py
@@ -7,7 +7,7 @@ from inspect import getsourcelines
 
 if os.path.isfile("version.txt"):
     os.remove("version.txt")
-version_file = open("version.txt", "wb")
+version_file = open("version.txt", "w")
 version_file.write(VERSION)
 modules = MODULE_LIST()
 scripts = []


### PR DESCRIPTION
1. open all files in non-binary mode by default.
2. Use io.BytesIO() for py2 and io.StringIO() for py3 for csv.writer
3. Update getmd5 to handle 'bytes' type class in py3.

All the tests pass for python 2 and for python 3 locally on Ubuntu 16.04 (64 bit).
@henrykironde @ethanwhite 