### PR TITLE
Remove check for datatype parameter being > 0

### DIFF
--- a/lib/engine.py
+++ b/lib/engine.py
@@ -277,12 +277,12 @@ class Engine(object):
             thistype = self.datatypes[thistype]
 
             if isinstance(thistype, tuple):
-                if len(datatype) > 1 and int(datatype[1]) > 0:
+                if len(datatype) > 1:
                     thistype = thistype[1] + "(" + str(datatype[1]) + ")"
                 else:
                     thistype = thistype[0]
             else:
-                if len(datatype) > 1 and int(datatype[1]) > 0:
+                if len(datatype) > 1:
                     thistype += "(" + str(datatype[1]) + ")"
         else:
             thistype = ""


### PR DESCRIPTION
The original code in `engine.convert_data_type()` checked to see if the
2nd value in `datatype` was > 0. This worked in Python 2, but it probably
shouldn't have because for the `decimal` type the 2nd value of datatype
is a string that includes information of the number of values to include
both before and after the decimal (e.g., the default is "30,20").

Python 3 changes this behavior to error when comparing the values of
strings and numbers, so in 6b52de0ff2f61b04200412c0eb1a7a1415328ea4
these values were convert to `int`s. This causes errors for all datasets
with decimal value columns when they are inserted into SQL databases.

This change removes the check There is no apparent reason why the value
should ever be <= 0, and if this was a poorly structured check for the
value existing it would fail to accomplish this task since `"" > 0`,
`[] > 0`, etc. evaluate to True. In addition to the automated tests I have
tested this on about 10 other datasets and found no issues.

Fixes #537.