### PR TITLE
utf-8 encode and decode 

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -16,8 +16,8 @@ import sys
 # sys removes the setdefaultencoding method at startup; reload to get it back
 reload(sys)
 if hasattr(sys, 'setdefaultencoding'):
-    # set default encoding to latin-1 for Python 2 to avoid decoding issues
-    sys.setdefaultencoding('latin-1')
+    # set default encoding to utf-8 to decode source text
+    sys.setdefaultencoding('utf-8')
 from retriever import VERSION, MASTER, SCRIPT_LIST, sample_script, current_platform
 from retriever.engines import engine_list
 from retriever.lib.repository import check_for_updates

--- a/lib/engine.py
+++ b/lib/engine.py
@@ -15,7 +15,7 @@ import gzip
 import tarfile
 import urllib.request, urllib.parse, urllib.error
 import csv
-
+import io
 from retriever import DATA_SEARCH_PATHS, DATA_WRITE_PATH
 from retriever.lib.cleanup import no_cleanup
 from retriever.lib.warning import Warning
@@ -157,7 +157,7 @@ class Engine(object):
 
         source = (skip_rows,
                   (self.table.column_names_row - 1,
-                   (open, (file_path, "rU"))))
+                   (io.open, (file_path, "rU", -1, 'utf-8', 'ignore'))))
         lines = gen_from_source(source)
 
         header = next(lines)
@@ -165,7 +165,7 @@ class Engine(object):
 
         source = (skip_rows,
                   (self.table.header_rows,
-                   (open, (file_path, "rU"))))
+                   (io.open, (file_path, "rU", -1, 'utf-8', 'ignore'))))
 
         if not self.table.delimiter:
             self.auto_get_delimiter(header)
@@ -603,7 +603,7 @@ class Engine(object):
         for inserting bulk data from files can override this function."""
         data_source = (skip_rows,
                        (self.table.header_rows,
-                        (open, (filename, 'rU'))))
+                        (io.open, (filename, 'rU', -1, 'utf-8', 'ignore'))))
         self.add_to_table(data_source)
 
     def insert_data_from_url(self, url):


### PR DESCRIPTION
Encoding the text as unicode, ignoring the characters which are non-utf8, and then decoding back seems to alleviate the problem. Downside is that now we lose certain characters like Ö and É.
Status: in progress

@ethanwhite @henrykironde 