### PR TITLE
Get try_install_all running and exclude more datasets

### DIFF
--- a/try_install_all.py
+++ b/try_install_all.py
@@ -24,7 +24,7 @@ if len(sys.argv) > 1:
     ]
 SCRIPT_LIST = SCRIPT_LIST()
 TEST_ENGINES = {}
-IGNORE = ["AvianBodyMass", "FIA"]
+IGNORE = ["AvianBodyMass", "FIA", "Bioclim", "PRISM", "vertnet"]
 
 for engine in ENGINE_LIST:
     opts = {}
@@ -42,7 +42,7 @@ for engine in ENGINE_LIST:
 errors = []
 for module in MODULE_LIST:
     for (key, value) in list(TEST_ENGINES.items()):
-        if value and module.SCRIPT.shortname not in IGNORE:
+        if value != None and (module.SCRIPT.shortname not in IGNORE):
             print("==>", module.__name__, value.name)
             try:
                 module.SCRIPT.download(value)


### PR DESCRIPTION
This updates try_install_all to get it running again. There was a very
strange error trigger by the `if value` check for the download only engine.
For some reason the value for the download only engine doesn't evaluate to
True or False when using `if value`.

Also excludes some of the new large datasets.