### PR TITLE
Use older worker image (VS 2015) for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+os: Previous Visual Studio 2015
 environment:
 
   matrix:


### PR DESCRIPTION
Due to updation of appveyor worker environment, the psycopg2 build fails.
Thus, the appveyor.yml has been updated to use a previous worker image
from 2015.