### PR TITLE
Turn off Codecov commenting on issues

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+# Codecov code coverage configuration file.
+# Overrides Codecov defaults
+
+# Turn on commenting on issues
+# Undocumented but described in:
+# https://github.com/codecov/support/issues/162#issuecomment-217634710
+
+comment: false


### PR DESCRIPTION
This information is already available in the checks and we don't
actively use those comments during review so they just create noise.