### PR TITLE
correct auto key for cross-tab

### DIFF
--- a/lib/engine.py
+++ b/lib/engine.py
@@ -71,6 +71,9 @@ class Engine(object):
             for line in lines:
                 split_line = self.table.split_on_delimiter(line)
                 initial_cols = len(self.table.columns) - (3 if hasattr(self.table, "ct_names") else 2)
+                # add one if auto increment is not set to get the right initial columns
+                if not self.table.columns[0][1][0] == "pk-auto":
+                    initial_cols += 1
                 begin = split_line[:initial_cols]
                 rest = split_line[initial_cols:]
                 n = 0

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import imp
 import os
 import shutil
+import pytest
 
 from retriever.lib.compile import compile_script
 from retriever import HOME_DIR, ENGINE_LIST
@@ -12,14 +13,28 @@ from retriever.lib.tools import file_2string
 simple_csv = {'name': 'simple_csv',
               'raw_data': "a,b,c\n1,2,3\n4,5,6\n",
               'script': "shortname: simple_csv\ntable: simple_csv, http://example.com/simple_csv.txt",
-              'expect_out': '"a","b","c"\n1,2,3\n4,5,6'}
+              'expect_out': 'a,b,c\n1,2,3\n4,5,6\n'}
+
+autopk_csv = {'name': 'autopk_csv',
+              'raw_data': "a,b,c\n1,2,3\n4,5,6\n",
+              'script': "shortname: autopk_csv\ntable: autopk_csv, http://example.com/autopk_csv.txt\n*column: record_id, pk-auto\n*column: a, int\n*column: b, int\n*column: c, int",
+              'expect_out': 'record_id,a,b,c\n1,1,2,3\n2,4,5,6\n'}
 
 crosstab = {'name': 'crosstab',
-            'raw_data': "a,b,c1,c2\n1,1,1.1,1.2\n1,2,2.1,2.2",
-            'script': "shortname: crosstab\ntable: crosstab, http://example.com/crosstab.txt\n*column: record_id, pk-auto\n*column: a, int\n*column: b, int\n*ct_column: c\n*column: val, ct-double\n*ct_names: c1,c2",
-            'expect_out': '"record_id","a","b","c","val"\n1,1,1,"c1",1.1\n2,1,1,"c2",1.2\n3,1,2,"c1",2.1\n4,1,2,"c2",2.2'}
+            'raw_data': "a,b,c1,c2\n1,1,1.1,1.2\n1,2,2.1,2.2\n",
+            'script': "shortname: crosstab\ntable: crosstab, http://example.com/crosstab.txt\n*column: a, int\n*column: b, int\n*ct_column: c\n*column: val, ct-double\n*ct_names: c1,c2",
+            'expect_out': 'a,b,c,val\n1,1,c1,1.1\n1,1,c2,1.2\n1,2,c1,2.1\n1,2,c2,2.2\n'}
 
-tests = [simple_csv, crosstab]
+autopk_crosstab = {'name': 'autopk_crosstab',
+            'raw_data': "a,b,c1,c2\n1,1,1.1,1.2\n1,2,2.1,2.2\n",
+            'script': "shortname: autopk_crosstab\ntable: autopk_crosstab, http://example.com/autopk_crosstab.txt\n*column: record_id, pk-auto\n*column: a, int\n*column: b, int\n*ct_column: c\n*column: val, ct-double\n*ct_names: c1,c2",
+            'expect_out': 'record_id,a,b,c,val\n1,1,1,c1,1.1\n2,1,1,c2,1.2\n3,1,2,c1,2.1\n4,1,2,c2,2.2\n'}
+
+tests = [simple_csv, autopk_csv, crosstab, autopk_crosstab]
+
+# create a tuple of all test scripts and expected values
+# (simple_csv, '"a","b","c"\n1,2,3\n4,5,6')
+test_parameters = [(test, test['expect_out']) for test in tests]
 
 
 def setup_module():
@@ -39,7 +54,18 @@ def teardown_module():
     for test in tests:
         shutil.rmtree(os.path.join(HOME_DIR, "raw_data", test['name']))
         os.remove(os.path.join(HOME_DIR, "scripts", test['name'] + '.script'))
-        os.remove(test['name']+'_'+test['name']+'.txt')
+        os.system("rm -r *{}".format(test['name']))
+
+
+def get_csv_string(dataset, engines, tmpdir):
+    workdir = tmpdir.mkdtemp()
+    workdir.chdir()
+    script_module = get_script_module(dataset["name"])
+    script_module.SCRIPT.download(engines)
+    script_module.SCRIPT.engine.final_cleanup()
+    script_module.SCRIPT.engine.to_csv()
+    obs_out = file_2string(dataset["name"] + "_" + dataset["name"] + ".txt")
+    return obs_out
 
 
 def get_script_module(script_name):
@@ -51,17 +77,7 @@ mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, csv_engine, downl
 csv_engine.opts = {'engine': 'csv', 'table_name': './{db}_{table}.txt'}
 
 
-def test_csv_from_csv():
-    simple_csv_module = get_script_module('simple_csv')
-    simple_csv_module.SCRIPT.download(csv_engine)
-    simple_csv_module.SCRIPT.engine.disconnect()
-    obs_out = file_2string("simple_csv_simple_csv.txt")
-    assert obs_out == simple_csv['expect_out']
-
-
-def test_crosstab_from_csv():
-    crosstab_module = get_script_module('crosstab')
-    crosstab_module.SCRIPT.download(csv_engine)
-    crosstab_module.SCRIPT.engine.disconnect()
-    obs_out = file_2string("crosstab_crosstab.txt")
-    assert obs_out == crosstab['expect_out']
+@pytest.mark.parametrize("dataset, expected",test_parameters)
+def test_csv_engine(dataset, expected, tmpdir):
+    csv_engine.opts = {'engine': 'csv', 'table_name': './{db}_{table}.txt'}
+    assert get_csv_string(dataset, csv_engine, tmpdir) == expected

--- a/test/test_regression_cli.py
+++ b/test/test_regression_cli.py
@@ -46,12 +46,13 @@ def get_csv_md5(dataset, engines, tmpdir):
 
 def setup_module():
     """Update retriever scripts and cd to test directory to find data"""
-    os.chdir("./test/")
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
     os.system("retriever update")
 
 
 def teardown_module():
     """Cleanup temporary output files after testing and return to root directory"""
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
     os.system("rm -r output*")
     os.system("rm -r raw_data/mom2003")
     os.system("rm -r raw_data/EA*")

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -30,13 +30,11 @@ test_engine.script = BasicTextTemplate(tables={'test': test_engine.table},
                                        shortname='test')
 test_engine.opts = {'database_name': '{db}_abc'}
 HOMEDIR = os.path.expanduser('~')
-test_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def setup_module():
     """"change directory to test directory"""
-    dir_path = os.path.dirname(os.path.abspath(__file__))
-    os.chdir(dir_path)
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 
 def teardown_method():
@@ -141,8 +139,6 @@ def test_find_file_present():
     test_engine.script.shortname = 'AvianBodySize'
     assert test_engine.find_file('avian_ssd_jan07.txt') == os.path.normpath(
         'raw_data/AvianBodySize/avian_ssd_jan07.txt')
-    os.system("rm -r raw_data/avianbodysize")
-    os.chdir('..')
 
 
 def test_format_data_dir():
@@ -196,7 +192,7 @@ def test_json2csv():
     """Test json2csv function
     creates a json file and tests the md5 sum calculation"""
     json_file = create_file("""[ {"User": "Alex", "Country": "US", "Age": "25"} ]""", 'output.json')
-    output_json = json2csv(json_file, "test/output_json.csv", header_values=["User", "Country", "Age"])
+    output_json = json2csv(json_file, "output_json.csv", header_values=["User", "Country", "Age"])
     obs_out = file_2string(output_json)
     os.remove(output_json)
     assert obs_out == 'User,Country,Age\nAlex,US,25'
@@ -214,7 +210,7 @@ def test_xml2csv():
                            "<Country>US</Country>S\n"
                            "<Age>24</Age>\n"
                            "</row>\n</root>", 'output.xml')
-    output_xml = xml2csv(xml_file, "test/output_xml.csv", header_values=["User", "Country", "Age"])
+    output_xml = xml2csv(xml_file, "output_xml.csv", header_values=["User", "Country", "Age"])
     obs_out = file_2string(output_xml)
     os.remove(output_xml)
     assert obs_out == "User,Country,Age\nAlex,US,25\nAlex,PT,25\nBen,US,24"


### PR DESCRIPTION
Cross-tab restructuring only worked when adding primary key.
This PR fixes#241 and includes integration test for cross tab
with and without auto primary keys.