### PR TITLE
Add latin-1 encoding to try_install_all

### DIFF
--- a/try_install_all.py
+++ b/try_install_all.py
@@ -14,6 +14,10 @@ import sys
 from retriever.lib.tools import choose_engine
 from retriever import MODULE_LIST, ENGINE_LIST, SCRIPT_LIST
 
+reload(sys)
+if hasattr(sys, 'setdefaultencoding'):
+    sys.setdefaultencoding('latin-1')
+
 MODULE_LIST = MODULE_LIST()
 ENGINE_LIST = ENGINE_LIST()
 if len(sys.argv) > 1:


### PR DESCRIPTION
Since try_install_all.py doesn't directly call the CLI the default
encoding isn't set.

This is actually the code I used when updating #551.