### PR TITLE
Provide informative failures for eBird and NPN

### DIFF
--- a/scripts/eBird_observation.py
+++ b/scripts/eBird_observation.py
@@ -1,6 +1,8 @@
 #retriever
 """EcoData Retriever script for the eBird Observation Dataset"""
 
+import sys
+
 from retriever.lib.templates import Script
 from retriever.lib.models import Table
 
@@ -14,6 +16,11 @@ class main(Script):
         self.description = "A collection of observations from birders through portals managed and maintained by local partner conservation organizations"
 
     def download(self, engine=None, debug=False):
+
+        ### eBird is currently unavailable
+        print("""eBird is not currently available via the Data Retriever because the eBird Observation dataset has been removed from DataOne and is no longer publicly available.""")
+        sys.exit()
+
         data_file_name = "eBird_Observation_Dataset_2013.csv"
         Script.download(self, engine, debug)
         self.engine.download_files_from_archive(self.urls["main"],

--- a/scripts/npn.py
+++ b/scripts/npn.py
@@ -6,6 +6,7 @@ standard_library.install_aliases()
 from builtins import range
 
 import os
+import sys
 import urllib.request, urllib.parse, urllib.error
 import zipfile
 from decimal import Decimal
@@ -25,6 +26,11 @@ class main(Script):
         self.description = "The data set was collected via Nature's Notebook phenology observation program (2009-present), and (2) Lilac and honeysuckle data (1955-present)"
         self.citation = "Schwartz, M. D., Ault, T. R., & J. L. Betancourt, 2012: Spring Onset Variations and Trends in the Continental USA: Past and Regional Assessment Using Temperature-Based Indices. International Journal of Climatology (published online, DOI: 10.1002/joc.3625)."
     def download(self, engine=None, debug=False):
+
+        ### NPN is currently unavailable due to an API upgrade
+        print("The NPN data is not currently available via the Data Retriever due to an API upgrade. Please check back soon.")
+        sys.exit()
+
         Script.download(self, engine, debug)
 
         engine = self.engine


### PR DESCRIPTION
eBird has removed it's data from DataOne and so no longer works.

NPN updated to a new API which requires an extensive reworking of the script.

These changes print useful information about why the datasets won't install,
instead of erroring without useful information.

This will also prevent them from triggering error reporting in try_install_all.py

Fixes #513.