### PR TITLE
Add row value length checks before adding to table

### DIFF
--- a/lib/engine.py
+++ b/lib/engine.py
@@ -95,11 +95,26 @@ class Engine(object):
             real_line_length = sum(1 for _ in len_source)
 
         total = self.table.record_id + real_line_length
+        pos = 0
         for line in real_lines:
             if not self.table.fixed_width:
                 line = line.strip()
             if line:
                 self.table.record_id += 1
+
+                # Check for single row distributed over multiple lines
+                val_list = self.table.split_on_delimiter(line)
+                while len(val_list) < len(self.table.get_column_datatypes()):
+                    line = line.rstrip('\n')
+                    if type(real_lines) != 'list':
+                        line += next(real_lines)
+                    else:
+                        line += real_lines[pos+1]
+                        real_lines.pop(pos+1)
+                    val_list = (self.table.split_on_delimiter(line))
+                pos += 1
+                assert(len(val_list) == len(self.table.get_column_datatypes()))
+
                 linevalues = self.table.values_from_line(line)
 
                 types = self.table.get_column_datatypes()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -19,7 +19,12 @@ crosstab = {'name': 'crosstab',
             'script': "shortname: crosstab\ntable: crosstab, http://example.com/crosstab.txt\n*column: record_id, pk-auto\n*column: a, int\n*column: b, int\n*ct_column: c\n*column: val, ct-double\n*ct_names: c1,c2",
             'expect_out': '"record_id","a","b","c","val"\n1,1,1,"c1",1.1\n2,1,1,"c2",1.2\n3,1,2,"c1",2.1\n4,1,2,"c2",2.2'}
 
-tests = [simple_csv, crosstab]
+extra_newline = {'name': 'extra_newline',
+              'raw_data': 'col1,col2,col3\n1,2\n,3\n',
+              'script': "shortname: extra_newline\ntable: extra_newline, http://example.com/extra_newline.txt",
+              'expect_out': '"col1","col2","col3"\n1,2,3'}
+
+tests = [simple_csv, crosstab, extra_newline]
 
 
 def setup_module():
@@ -65,3 +70,10 @@ def test_crosstab_from_csv():
     crosstab_module.SCRIPT.engine.disconnect()
     obs_out = file_2string("crosstab_crosstab.txt")
     assert obs_out == crosstab['expect_out']
+
+def test_extra_newline():
+    extra_newline_module = get_script_module('extra_newline')
+    extra_newline_module.SCRIPT.download(csv_engine)
+    extra_newline_module.SCRIPT.engine.disconnect()
+    obs_out = file_2string("extra_newline_extra_newline.txt")
+    assert obs_out == extra_newline['expect_out']


### PR DESCRIPTION
Some datasets have an extra newline character in their rows, which causes
retriever to read them as separate instances on data, This causes mismatch
int the numbers if columns and data values, producing IndexError exceptions
in a few cases.

This commit adds a loop to keep adding lines to a row until the number of values
equals the number of columns, before adding the row to the table.

Closes #567 and reduces the severity of #551 