### PR TITLE
add cross-platform urlretrieve

### DIFF
--- a/lib/engine.py
+++ b/lib/engine.py
@@ -14,9 +14,12 @@ import getpass
 import zipfile
 import gzip
 import tarfile
-import urllib.request, urllib.parse, urllib.error
 import csv
 import io
+if sys.version_info[0] >= 3:
+    from urllib.request import urlretrieve
+else:
+    from urllib import urlretrieve
 from retriever import DATA_SEARCH_PATHS, DATA_WRITE_PATH
 from retriever.lib.cleanup import no_cleanup
 from retriever.lib.warning import Warning
@@ -388,7 +391,7 @@ class Engine(object):
             path = self.format_filename(filename)
             self.create_raw_data_dir()
             print("Downloading " + filename + "...")
-            response = urllib.request.urlretrieve(url, path)
+            urlretrieve(url, path)
 
 
     def download_files_from_archive(self, url, filenames, filetype="zip",


### PR DESCRIPTION
with out specifying the library to use some urls would not
get fetched on python2.

fixes #571