### PR TITLE
Use `extract_values` when checking for mid-row line endings

### DIFF
--- a/lib/engine.py
+++ b/lib/engine.py
@@ -109,7 +109,7 @@ class Engine(object):
                 self.table.record_id += 1
 
                 # Check for single row distributed over multiple lines
-                val_list = self.table.split_on_delimiter(line)
+                val_list = self.table.extract_values(line)
                 while len(val_list) < len(self.table.get_column_datatypes()):
                     line = line.rstrip('\n')
                     if type(real_lines) != 'list':
@@ -117,7 +117,7 @@ class Engine(object):
                     else:
                         line += real_lines[pos+1]
                         real_lines.pop(pos+1)
-                    val_list = (self.table.split_on_delimiter(line))
+                    val_list = (self.table.extract_values(line))
                 pos += 1
 
                 linevalues = self.table.values_from_line(line)


### PR DESCRIPTION
When handling extra mid-row line endings we split the line to check if there
are enough values. This was added in 9f05ea3, but it ran `split_on_delimiter`
without checking if the table has a delimiter and so errored on fixed-width
tables. This replaces `split_on_delimiter` with `extract_values` to properly
split the line in both delimited and fixed-width cases.

Fixes #580.