### PR TITLE
Only use `extract_values` for splitting lines

### DIFF
--- a/lib/engine.py
+++ b/lib/engine.py
@@ -72,7 +72,7 @@ class Engine(object):
             lines = gen_from_source(data_source)
             real_lines = []
             for line in lines:
-                split_line = self.table.split_on_delimiter(line)
+                split_line = self.table.extract_values(line)
                 initial_cols = len(self.table.columns) - (3 if hasattr(self.table, "ct_names") else 2)
                 # add one if auto increment is not set to get the right initial columns
                 if not self.table.columns[0][1][0] == "pk-auto":

--- a/lib/table.py
+++ b/lib/table.py
@@ -40,13 +40,7 @@ class Table(object):
         Replaces database keywords with alternatives.
         Replaces special characters and spaces.
         """
-        if self.fixed_width:
-            column_names = self.extract_values(header)
-        else:
-            # Get column names from header row
-            values = self.split_on_delimiter(header)
-            column_names = [name.strip() for name in values]
-
+        column_names = self.extract_values(header)
         columns = [self.clean_column_name(x) for x in column_names]
         column_values = {x: [] for x in columns if x}
         self.cleaned_columns = True
@@ -102,6 +96,14 @@ class Table(object):
         return column_name
 
     def split_on_delimiter(self, line):
+        """Splits a line using the table's delimiter
+
+        This function does not work with fixed-width data and is only a
+        helper function for `extract_values`. `extract_values` should be
+        used instead when there is a general need to split the values in
+        a line of data.
+
+        """
         dialect = csv.excel
         dialect.escapechar = "\\"
         r = csv.reader([line], dialect=dialect, delimiter=self.delimiter)
@@ -148,8 +150,12 @@ class Table(object):
         return linevalues
 
     def extract_values(self, line):
-        """Given a line of data, this function returns a list of the individual
-        data values."""
+        """Return list of data values from a line of data represented as a string
+
+        This function correctly handles both fixed-width and delimited data and
+        should be used instead of `split_on_delimiter` when splitting lines.
+
+        """
         if self.fixed_width:
             pos = 0
             values = []

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -41,10 +41,18 @@ def teardown_method():
     """Cleanup temporary output files after testing"""
     os.chdir("..")
 
+
 def test_auto_get_columns():
     """Basic test of getting column labels from header"""
     test_engine.table.delimiter = ","
     columns, column_values = test_engine.table.auto_get_columns("a,b,c,d")
+    assert columns == [['a', None], ['b', None], ['c', None], ['d', None]]
+
+
+def test_auto_get_columns_extra_whitespace():
+    """Test getting column labels from header with extra whitespace"""
+    test_engine.table.delimiter = ","
+    columns, column_values = test_engine.table.auto_get_columns(" a ,b, c,d  ")
     assert columns == [['a', None], ['b', None], ['c', None], ['d', None]]
 
 


### PR DESCRIPTION
`extract_values` properly handles both fixed width and delimited data
and should therefore be used anytime it is necessary to split up rows
of data. This replaces the few instances of `split_on_delimiter` used
outside of `extract_values` with `extract_values` and improves the
documentation for both functions to make clear that `extract_values`
should be used preferentially.

Includes a new test for `auto_get_columns` to make sure it is still
performing the removed `.strip()` step.