### PR TITLE
refine conversion of strings to floats in the engine

### DIFF
--- a/lib/engine.py
+++ b/lib/engine.py
@@ -565,10 +565,11 @@ class Engine(object):
                 return "null"
         elif datatype in ("double", "decimal"):
             if strvalue:
-                decimals = float(strvalue)
-                return str(decimals)
-            else:
-                return "null"
+                try:
+                    decimals = float(strvalue)
+                    return str(decimals)
+                except:
+                    return "null"
         elif datatype == "char":
             if strvalue.lower() in nulls:
                 return "null"


### PR DESCRIPTION
We did not handle the conversion of strings to floats appropriately.
In some dataset, where null values are not specified,
installing will give some error.
for example, in FrayJorge 'ND' looks like the null value and
since we can not change to float, the system will error,

In the current PR, if we can't change a value to float, we
take that as a null