### PR TITLE
Update Python 3 version to 3.5 for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x"
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
   # postgres


### PR DESCRIPTION
Also resolves pyyaml installation bug with 3.4 for datapackage.JSON branch ( #595 ) 
@henrykironde @ethanwhite 