### PR TITLE
force list by typecasting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ for script_num, script in enumerate(script_list, start=1):
     if script.ref.strip():
         reference_link = script.ref
     elif bool(script.urls.values()):
-        reference_link = script.urls.values()[0].rpartition('/')[0]
+        reference_link = list(script.urls.values())[0].rpartition('/')[0]
     else:
         reference_link = ""
     datasetfile.write("| " + str(script_num) + ". **{}** \n| shortname: {}\n| reference: {}\n\n".format(script.name, script.shortname, reference_link))


### PR DESCRIPTION
Readthedoc's server returns an error on conf.py.
It assumes `script.urls.values()` is a dict.
This change typecasts the value to list.