### PR TITLE
test retriever using downloaded scripts

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -44,6 +44,7 @@ for dir in (HOME_DIR, os.path.join(HOME_DIR, 'raw_data'), os.path.join(HOME_DIR,
             print("The Retriever lacks permission to access the ~/.retriever/ directory.")
             raise
 SCRIPT_SEARCH_PATHS = [
+    "./",
     'scripts',
     os.path.join(HOME_DIR, 'scripts/')
 ]

--- a/lib/compile.py
+++ b/lib/compile.py
@@ -141,12 +141,12 @@ def compile_script(script_file):
 
 
 def add_dialect(table_dict, table):
-    '''
+    """
     Reads dialect key of JSON script and extracts key-value pairs to store them
     in python script
 
     Contains properties such 'nulls', delimiter', etc
-    '''
+    """
     for (key, val) in table['dialect'].items():
         # dialect related key-value pairs
         # copied as is
@@ -161,13 +161,13 @@ def add_dialect(table_dict, table):
 
 
 def add_schema(table_dict, table):
-    '''
+    """
     Reads schema key of JSON script and extracts values to store them in
     python script
 
     Contains properties related to table schema, such as 'fields' and cross-tab
     column name ('ct_column').
-    '''
+    """
     for (key, val) in table['schema'].items():
         # schema related key-value pairs
 
@@ -178,14 +178,14 @@ def add_schema(table_dict, table):
             column_list = []
             for obj in val:
                 # fields is a collection of JSON objects
-                #(similar to a list of dicts in python)
+                # (similar to a list of dicts in python)
 
                 if "size" in obj:
                     column_list.append((obj["name"],
                                         (obj["type"], obj["size"])))
                 else:
                     column_list.append((obj["name"],
-                                        (obj["type"], )))
+                                        (obj["type"],)))
 
             table_dict["columns"] = column_list
 
@@ -197,12 +197,16 @@ def add_schema(table_dict, table):
 
 
 def compile_json(json_file):
-    '''
+    """
     Function to compile JSON script files to python scripts
     The scripts are created with `retriever create_json <script_name` using
     command line
-    '''
+    """
     json_object = json.load(open(json_file + ".json", "r"))
+
+    if "retriever" not in json_object.keys():
+        # Compile only files that have retriever key
+        return
 
     values = {}
     values['urls'] = {}
@@ -233,7 +237,7 @@ def compile_json(json_file):
             # Array of table objects
             tables = {}
             for table in value:
-                 # Maintain a dict for table keys and values
+                # Maintain a dict for table keys and values
                 table_dict = {}
 
                 try:

--- a/lib/parse_script_to_json.py
+++ b/lib/parse_script_to_json.py
@@ -15,6 +15,7 @@ def parse_script_to_json(script_file, location=SCRIPT_DIR):
     replace = []
     keys_to_ignore = ["template"]
     urls = {}
+    values["retriever"] = "True"
 
     for line in [str(line).strip() for line in definition]:
         if line and ':' in line and not line[0] == '#':

--- a/scripts/Adler2007.json
+++ b/scripts/Adler2007.json
@@ -151,6 +151,7 @@
             "url": "http://esapubs.org/archive/ecol/E088/161/monthly_ppt.csv"
         }
     ],
+    "retriever": "True",
     "title": "Kansas plant quadrats (Ecological Archives 2007)",
     "urls": {
         "main": "http://esapubs.org/archive/ecol/E088/161/allrecords.csv",

--- a/scripts/AmnioteDB.json
+++ b/scripts/AmnioteDB.json
@@ -98,6 +98,7 @@
             "url": "http://esapubs.org/archive/ecol/E096/269/Data_Files/Amniote_Database_Aug_2015.csv"
         }
     ],
+    "retriever": "True",
     "title": "Amniote life History database",
     "urls": {
         "main": "http://esapubs.org/archive/ecol/E096/269/Data_Files/Amniote_Database_Aug_2015.csv"

--- a/scripts/Anderson2011.json
+++ b/scripts/Anderson2011.json
@@ -23,6 +23,7 @@
             "url": "http://esapubs.org/archive/ecol/E092/143/species_list.csv"
         }
     ],
+    "retriever": "True",
     "title": "Northern mixed prairie maps - Anderson et al. 2011",
     "urls": {
         "allrecords_cover": "http://esapubs.org/archive/ecol/E092/143/allrecords_cover.csv",

--- a/scripts/ArcticBreedBird.json
+++ b/scripts/ArcticBreedBird.json
@@ -14,6 +14,7 @@
             "url": "http://esapubs.org/archive/ecol/E094/243/Antarctic_Site_Inventory_census_data_1994_2012.csv"
         }
     ],
+    "retriever": "True",
     "title": "Antarctic Site Inventory breeding bird survey data, 1994-2013",
     "urls": {
         "species": "http://esapubs.org/archive/ecol/E094/243/Antarctic_Site_Inventory_census_data_1994_2012.csv"

--- a/scripts/AvianBodySize.json
+++ b/scripts/AvianBodySize.json
@@ -19,6 +19,7 @@
             "url": "http://esapubs.org/archive/ecol/E088/096/avian_ssd_jan07.txt"
         }
     ],
+    "retriever": "True",
     "title": "Avian Body Size Ecological Archives 2007",
     "urls": {
         "species": "http://esapubs.org/archive/ecol/E088/096/avian_ssd_jan07.txt"

--- a/scripts/CForBioData.json
+++ b/scripts/CForBioData.json
@@ -18,6 +18,7 @@
             "url": "http://esapubs.org/archive/ecol/E095/177/CForBioData_v1.0.txt"
         }
     ],
+    "retriever": "True",
     "title": "Biomass and Its Allocation in Chinese Forest Ecosystems - Luo, et al., 2014",
     "urls": {
         "biomass": "http://esapubs.org/archive/ecol/E095/177/CForBioData_v1.0.txt"

--- a/scripts/DelMoral2010.json
+++ b/scripts/DelMoral2010.json
@@ -157,6 +157,7 @@
             "url": "http://esapubs.org/archive/ecol/E091/152/MSH_PLOT_DESCRIPTORS.csv"
         }
     ],
+    "retriever": "True",
     "title": "Vegetation plots - del Moral, 2010",
     "urls": {
         "plots": "http://esapubs.org/archive/ecol/E091/152/MSH_PLOT_DESCRIPTORS.csv",

--- a/scripts/EltonTraits.json
+++ b/scripts/EltonTraits.json
@@ -33,6 +33,7 @@
             "url": "http://esapubs.org/archive/ecol/E095/178/MamFuncDatSources.txt"
         }
     ],
+    "retriever": "True",
     "title": "Mammal and Bird foraging attributes -- Wilman, et al., 2014",
     "urls": {
         "BirdCitations": "http://esapubs.org/archive/ecol/E095/178/BirdFuncDatSources.txt",

--- a/scripts/FishParasiteHosts.json
+++ b/scripts/FishParasiteHosts.json
@@ -92,6 +92,7 @@
             "url": "http://esapubs.org/archive/ecol/E094/045/FPEDB.csv"
         }
     ],
+    "retriever": "True",
     "title": "Fish parasite host ecological characteristics - Strona, et al., 2013",
     "urls": {
         "host_characteristics": "http://esapubs.org/archive/ecol/E094/045/FPEDB.csv"

--- a/scripts/FrayJorge.json
+++ b/scripts/FrayJorge.json
@@ -243,6 +243,7 @@
             "url": "http://esapubs.org/archive/ecol/E094/084/data/Fray_Jorge_Precipitation_1989-2005.csv"
         }
     ],
+    "retriever": "True",
     "title": "Fray Jorge community database",
     "urls": {
         "annuals": "http://esapubs.org/archive/ecol/E094/084/data/Fray_Jorge_Annuals_1989-2005.txt",

--- a/scripts/HomeRanges.json
+++ b/scripts/HomeRanges.json
@@ -18,6 +18,7 @@
             "url": "http://datadryad.org/bitstream/handle/10255/dryad.84768/Tamburelloetal_HomeRangeDatabase.csv"
         }
     ],
+    "retriever": "True",
     "title": "Database of Vertebrate Home Range Sizes- Tamburello , et al., 2015",
     "urls": {
         "ranges": "http://datadryad.org/bitstream/handle/10255/dryad.84768/Tamburelloetal_HomeRangeDatabase.csv"

--- a/scripts/MCDB.json
+++ b/scripts/MCDB.json
@@ -40,6 +40,7 @@
             "url": "http://esapubs.org/archive/ecol/E092/201/data/MCDB_trapping.csv"
         }
     ],
+    "retriever": "True",
     "title": "Mammal Community DataBase (Ecological Archives 2011)",
     "urls": {
         "communities": "http://esapubs.org/archive/ecol/E092/201/data/MCDB_communities.csv",

--- a/scripts/MammalDIET.json
+++ b/scripts/MammalDIET.json
@@ -142,6 +142,7 @@
             "url": "http://datadryad.org/bitstream/handle/10255/dryad.64565/MammalDIET_v1.0.txt"
         }
     ],
+    "retriever": "True",
     "title": "MammalDIET",
     "urls": {
         "diet": "http://datadryad.org/bitstream/handle/10255/dryad.64565/MammalDIET_v1.0.txt"

--- a/scripts/MammalLH.json
+++ b/scripts/MammalLH.json
@@ -15,6 +15,7 @@
             "url": "http://esapubs.org/archive/ecol/E084/093/Mammal_lifehistories_v2.txt"
         }
     ],
+    "retriever": "True",
     "title": "Mammal Life History Database - Ernest, et al., 2003",
     "urls": {
         "species": "http://esapubs.org/archive/ecol/E084/093/Mammal_lifehistories_v2.txt"

--- a/scripts/MammalMR2010.json
+++ b/scripts/MammalMR2010.json
@@ -19,6 +19,7 @@
             "url": "http://www.esapubs.org/archive/ecol/E091/198/data.txt"
         }
     ],
+    "retriever": "True",
     "title": "Phylogeny and metabolic rates in mammals (Ecological Archives 2010)",
     "urls": {
         "MammalMR2010": "http://www.esapubs.org/archive/ecol/E091/198/data.txt"

--- a/scripts/MarineSize.json
+++ b/scripts/MarineSize.json
@@ -20,6 +20,7 @@
             "url": "http://www.esapubs.org/Archive/ecol/E089/051/Predator_and_prey_body_sizes_in_marine_food_webs_vsn3.txt"
         }
     ],
+    "retriever": "True",
     "title": "Marine Predator and Prey Body Sizes (Ecological Archives 2008)",
     "urls": {
         "main": "http://www.esapubs.org/Archive/ecol/E089/051/Predator_and_prey_body_sizes_in_marine_food_webs_vsn3.txt"

--- a/scripts/Matter2014.json
+++ b/scripts/Matter2014.json
@@ -49,6 +49,7 @@
             "url": "http://esapubs.org/archive/ecol/E095/258/Landscape.csv"
         }
     ],
+    "retriever": "True",
     "title": "Spatial Population Data Alpine Butterfly -- Matter et al 2014",
     "urls": {
         "Dispersal": "http://esapubs.org/archive/ecol/E095/258/Dispersal.csv",

--- a/scripts/McGlinn2010.json
+++ b/scripts/McGlinn2010.json
@@ -47,6 +47,7 @@
             "url": "http://esapubs.org/archive/ecol/E091/124/TGPP_clim.csv"
         }
     ],
+    "retriever": "True",
     "title": "Vascular plant composition - McGlinn, et al., 2010",
     "urls": {
         "climate": "http://esapubs.org/archive/ecol/E091/124/TGPP_clim.csv",

--- a/scripts/MiscAbundanceDB.json
+++ b/scripts/MiscAbundanceDB.json
@@ -22,6 +22,7 @@
             "url": "http://files.figshare.com/2023506/Citations_table_abundances.csv"
         }
     ],
+    "retriever": "True",
     "title": "Miscellaneous Abundance Database (figshare 2012)",
     "urls": {
         "citations": "http://files.figshare.com/2023506/Citations_table_abundances.csv",

--- a/scripts/MoM2003.json
+++ b/scripts/MoM2003.json
@@ -68,6 +68,7 @@
             "url": "http://www.esapubs.org/Archive/ecol/E084/094/MOMv3.3.txt"
         }
     ],
+    "retriever": "True",
     "title": "Masses of Mammals (Ecological Archives 2003)",
     "urls": {
         "MOM": "http://www.esapubs.org/Archive/ecol/E084/094/MOMv3.3.txt"

--- a/scripts/Palmer2007.json
+++ b/scripts/Palmer2007.json
@@ -53,6 +53,7 @@
             "url": "http://esapubs.org/archive/ecol/E088/162/Oosting_env.txt"
         }
     ],
+    "retriever": "True",
     "title": "North Carolina forest plants (Ecological Archives 2007)",
     "urls": {
         "env": "http://esapubs.org/archive/ecol/E088/162/Oosting_env.txt",

--- a/scripts/Pantheria.json
+++ b/scripts/Pantheria.json
@@ -15,6 +15,7 @@
             "url": "http://esapubs.org/archive/ecol/E090/184/PanTHERIA_1-0_WR05_Aug2008.txt"
         }
     ],
+    "retriever": "True",
     "title": "Pantheria (Ecological Archives 2009 - WR05)",
     "urls": {
         "species": "http://esapubs.org/archive/ecol/E090/184/PanTHERIA_1-0_WR05_Aug2008.txt"

--- a/scripts/PhytoplankonBiovolume.json
+++ b/scripts/PhytoplankonBiovolume.json
@@ -69,6 +69,7 @@
             "url": "http://esapubs.org/archive/ecol/E095/257/taxa_table_030614.csv"
         }
     ],
+    "retriever": "True",
     "title": "Biovolumes for freshwater phytoplankton - Colin et al. 2014",
     "urls": {
         "bvd_genus_ag": "http://esapubs.org/archive/ecol/E095/257/bvd_genus_ag_030614.csv",

--- a/scripts/PlantTaxonomy.json
+++ b/scripts/PlantTaxonomy.json
@@ -47,6 +47,7 @@
             "url": "http://plants.usda.gov/java/downloadData?fileName=plantlst.txt&static=true"
         }
     ],
+    "retriever": "True",
     "title": "USDA plants",
     "urls": {
         "PlantTaxonomy": "http://plants.usda.gov/java/downloadData?fileName=plantlst.txt&static=true"

--- a/scripts/PortalMammals.json
+++ b/scripts/PortalMammals.json
@@ -175,6 +175,7 @@
             "url": "https://ndownloader.figshare.com/files/3299474"
         }
     ],
+    "retriever": "True",
     "scan_lines": "40000",
     "title": "Portal Project Mammals (Ecological Archives 2009)",
     "urls": {

--- a/scripts/Ramesh2010.json
+++ b/scripts/Ramesh2010.json
@@ -185,6 +185,7 @@
             "url": "http://esapubs.org/archive/ecol/E091/216/Species_list.txt"
         }
     ],
+    "retriever": "True",
     "title": "Indian Forest Stand Structure (Ecological Archives 2010)",
     "urls": {
         "macroplots": "http://esapubs.org/archive/ecol/E091/216/Macroplot_data.txt",

--- a/scripts/SonoranPerennials.json
+++ b/scripts/SonoranPerennials.json
@@ -98,6 +98,7 @@
             "url": "http://esapubs.org/archive/ecol/E094/083/Photo_info.csv"
         }
     ],
+    "retriever": "True",
     "title": "Sonoran Desert Perennials",
     "urls": {
         "Count1906": "http://esapubs.org/archive/ecol/E094/083/Count1906.csv",

--- a/scripts/Steppe_plants_2013.json
+++ b/scripts/Steppe_plants_2013.json
@@ -91,6 +91,7 @@
             "url": "http://esapubs.org/archive/ecol/E094/128/species_name_changes.csv"
         }
     ],
+    "retriever": "True",
     "title": "Shortgrass steppe plants.",
     "urls": {
         "allrecords_cover": "http://esapubs.org/archive/ecol/E094/128/allrecords_cover.csv",

--- a/scripts/TreeWesternGhats.json
+++ b/scripts/TreeWesternGhats.json
@@ -29,6 +29,7 @@
             "url": "http://esapubs.org/archive/ecol/E092/115/UPSP_Species_list2.txt"
         }
     ],
+    "retriever": "True",
     "title": "Twenty years tree demography in Western Ghats of India - Pelissier, et al., 2011",
     "urls": {
         "ind_loc_girth": "http://esapubs.org/archive/ecol/E092/115/UPSP_Demo_data.txt",

--- a/scripts/Woods2009.json
+++ b/scripts/Woods2009.json
@@ -151,6 +151,7 @@
             "url": "http://www.esapubs.org/archive/ecol/E090/251/datafiles/sampling_history.txt"
         }
     ],
+    "retriever": "True",
     "title": "Michigan canopy dynamics (Ecological Archives 2009)",
     "urls": {
         "all_plots_1935_1948": "http://www.esapubs.org/archive/ecol/E090/251/datafiles/all_plots_1935_1948.txt",

--- a/scripts/Zachmann2010.json
+++ b/scripts/Zachmann2010.json
@@ -218,6 +218,7 @@
             "url": "http://esapubs.org/archive/ecol/E091/243/total_monthly_sno.csv"
         }
     ],
+    "retriever": "True",
     "title": "Sagebrush steppe quadrats (Ecological Archives 2010)",
     "urls": {
         "counts": "http://esapubs.org/archive/ecol/E091/243/annuals_counts_v3.csv",

--- a/scripts/leaf_herbivory.json
+++ b/scripts/leaf_herbivory.json
@@ -13,6 +13,7 @@
             "url": "http://www.esapubs.org/archive/ecol/E095/065/Leaf_herbivory.csv"
         }
     ],
+    "retriever": "True",
     "title": "Leaf herbivory dataset",
     "urls": {
         "Leaf_herbivory": "http://www.esapubs.org/archive/ecol/E095/065/Leaf_herbivory.csv"

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -46,6 +46,8 @@ tests = [simple_csv, autopk_csv, crosstab, autopk_crosstab, skip_csv, extra_newl
 # Create a tuple of all test scripts and expected values
 # (simple_csv, '"a","b","c"\n1,2,3\n4,5,6')
 test_parameters = [(test, test['expect_out']) for test in tests]
+file_location = os.path.dirname(os.path.realpath(__file__))
+retriever_root_dir = os.path.abspath(os.path.join(file_location, os.pardir))
 
 
 def setup_module():
@@ -88,7 +90,7 @@ def get_output_as_csv(dataset, engines, tmpdir, db):
     if engines.opts["engine"] != 'csv':
         csv_file += '.csv'
     obs_out = file_2string(csv_file)
-    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    os.chdir(retriever_root_dir)
     return obs_out
 
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -3,14 +3,13 @@ from __future__ import print_function
 import imp
 import os
 import shutil
-import pytest
 
+import pytest
 from retriever.lib.compile import compile_json
 from retriever.lib.parse_script_to_json import parse_script_to_json
 from retriever import HOME_DIR, ENGINE_LIST
 from retriever.lib.tools import file_2string
 from retriever.lib.tools import create_file
-
 
 simple_csv = {'name': 'simple_csv',
               'raw_data': "a,b,c\n1,2,3\n4,5,6\n",
@@ -28,19 +27,19 @@ crosstab = {'name': 'crosstab',
             'expect_out': 'a,b,c,val\n1,1,c1,1.1\n1,1,c2,1.2\n1,2,c1,2.1\n1,2,c2,2.2\n'}
 
 autopk_crosstab = {'name': 'autopk_crosstab',
-            'raw_data': "a,b,c1,c2\n1,1,1.1,1.2\n1,2,2.1,2.2\n",
-            'script': "shortname: autopk_crosstab\ntable: autopk_crosstab, http://example.com/autopk_crosstab.txt\n*column: record_id, pk-auto\n*column: a, int\n*column: b, int\n*ct_column: c\n*column: val, ct-double\n*ct_names: c1,c2",
-            'expect_out': 'record_id,a,b,c,val\n1,1,1,c1,1.1\n2,1,1,c2,1.2\n3,1,2,c1,2.1\n4,1,2,c2,2.2\n'}
+                   'raw_data': "a,b,c1,c2\n1,1,1.1,1.2\n1,2,2.1,2.2\n",
+                   'script': "shortname: autopk_crosstab\ntable: autopk_crosstab, http://example.com/autopk_crosstab.txt\n*column: record_id, pk-auto\n*column: a, int\n*column: b, int\n*ct_column: c\n*column: val, ct-double\n*ct_names: c1,c2",
+                   'expect_out': 'record_id,a,b,c,val\n1,1,1,c1,1.1\n2,1,1,c2,1.2\n3,1,2,c1,2.1\n4,1,2,c2,2.2\n'}
 
 skip_csv = {'name': 'skip_csv',
-              'raw_data': "a,b,c\n1,2,3\n4,5,6\n",
-              'script': "shortname: skip_csv\ntable: skip_csv, http://example.com/skip_csv.txt\n*do_not_bulk_insert: True\n*column: a, skip\n*column: b, int\n*column: c, int",
-              'expect_out': 'b,c\n2,3\n5,6\n'}
+            'raw_data': "a,b,c\n1,2,3\n4,5,6\n",
+            'script': "shortname: skip_csv\ntable: skip_csv, http://example.com/skip_csv.txt\n*do_not_bulk_insert: True\n*column: a, skip\n*column: b, int\n*column: c, int",
+            'expect_out': 'b,c\n2,3\n5,6\n'}
 
 extra_newline = {'name': 'extra_newline',
-                'raw_data': 'col1,col2,col3\n1,2\n,3\n',
-                'script': "shortname: extra_newline\ntable: extra_newline, http://example.com/extra_newline.txt",
-                'expect_out': 'col1,col2,col3\n1,2,3\n'}
+                 'raw_data': 'col1,col2,col3\n1,2\n,3\n',
+                 'script': "shortname: extra_newline\ntable: extra_newline, http://example.com/extra_newline.txt",
+                 'expect_out': 'col1,col2,col3\n1,2,3\n'}
 
 tests = [simple_csv, autopk_csv, crosstab, autopk_crosstab, skip_csv, extra_newline]
 
@@ -56,7 +55,7 @@ def setup_module():
             os.makedirs(os.path.join(HOME_DIR, "raw_data", test['name']))
         create_file(test['raw_data'], os.path.join(HOME_DIR, "raw_data", test['name'], test['name'] + '.txt'))
         create_file(test['script'], os.path.join(HOME_DIR, "scripts", test['name'] + '.script'))
-        parse_script_to_json(test['name'], location = os.path.join(HOME_DIR, "scripts"))
+        parse_script_to_json(test['name'], location=os.path.join(HOME_DIR, "scripts"))
         compile_json(os.path.join(HOME_DIR, "scripts", test['name']))
 
 
@@ -64,11 +63,12 @@ def teardown_module():
     """Remove test data and scripts from .retriever directories"""
     for test in tests:
         shutil.rmtree(os.path.join(HOME_DIR, "raw_data", test['name']))
-        os.remove(os.path.join(HOME_DIR , "scripts", test['name'] + '.script'))
-        os.remove(os.path.join(HOME_DIR , "scripts", test['name'] + '.json'))
-        os.remove(os.path.join(HOME_DIR , "scripts", test['name'] + '.py'))
+        os.remove(os.path.join(HOME_DIR, "scripts", test['name'] + '.script'))
+        os.remove(os.path.join(HOME_DIR, "scripts", test['name'] + '.json'))
+        os.remove(os.path.join(HOME_DIR, "scripts", test['name'] + '.py'))
         os.system("rm -r *{}".format(test['name']))
         os.system("rm testdb.sqlite")
+
 
 def get_output_as_csv(dataset, engines, tmpdir, db):
     """Install dataset and return the output as a string version of the csv
@@ -97,16 +97,17 @@ def get_script_module(script_name):
     file, pathname, desc = imp.find_module(script_name, [os.path.join(HOME_DIR, "scripts")])
     return imp.load_module(script_name, file, pathname, desc)
 
+
 mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, csv_engine, download_engine, json_engine, xml_engine = ENGINE_LIST()
 
 
-@pytest.mark.parametrize("dataset, expected",test_parameters)
+@pytest.mark.parametrize("dataset, expected", test_parameters)
 def test_csv_integration(dataset, expected, tmpdir):
     csv_engine.opts = {'engine': 'csv', 'table_name': '{db}_{table}'}
     assert get_output_as_csv(dataset, csv_engine, tmpdir, db=dataset["name"]) == expected
 
 
-@pytest.mark.parametrize("dataset, expected",test_parameters)
+@pytest.mark.parametrize("dataset, expected", test_parameters)
 def test_sqlite_integration(dataset, expected, tmpdir):
     dbfile = os.path.normpath(os.path.join(os.getcwd(), 'testdb.sqlite'))
     sqlite_engine.opts = {'engine': 'sqlite', 'file': dbfile, 'table_name': '{db}_{table}'}

--- a/test/test_regression_cli.py
+++ b/test/test_regression_cli.py
@@ -9,12 +9,12 @@ if hasattr(sys, 'setdefaultencoding'):
     sys.setdefaultencoding('latin-1')
 import pytest
 from retriever.lib.tools import getmd5
-from retriever import SCRIPT_SEARCH_PATHS, ENGINE_LIST
+from retriever import ENGINE_LIST
 
 mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, csv_engine, download_engine, json_engine, xml_engine = ENGINE_LIST()
-dir_path = os.path.dirname(os.path.abspath(__file__))
-site_root = os.path.dirname(os.path.realpath(__file__))
-parent = os.path.abspath(os.path.join(site_root, os.pardir))
+file_location = os.path.dirname(os.path.realpath(__file__))
+retriever_root_dir = os.path.abspath(os.path.join(file_location, os.pardir))
+working_script_dir = os.path.abspath(os.path.join(retriever_root_dir, "scripts"))
 HOMEDIR = os.path.expanduser('~')
 
 download_md5 = [
@@ -31,13 +31,8 @@ db_md5 = [
 
 
 def get_script_module(script_name):
-    """Load a script module from the downloaded scripts directory in the retriever
-
-    This ensures that tests are performed on the retriever source downloaded
-    Since this module is run in the test directory, we get the parent directory
-    using the module's location
-    """
-    file, pathname, desc = imp.find_module(script_name, [os.path.join(parent, "scripts")])
+    """Load a script module from the downloaded scripts directory in the retriever"""
+    file, pathname, desc = imp.find_module(script_name, [working_script_dir])
     return imp.load_module(script_name, file, pathname, desc)
 
 
@@ -54,17 +49,17 @@ def get_csv_md5(dataset, engines, tmpdir):
 
 def setup_module():
     """Update retriever scripts and cd to test directory to find data"""
-    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    os.chdir(retriever_root_dir)
+    os.system('cp -r {0} {1}'.format(os.path.join(retriever_root_dir, "test/raw_data"), retriever_root_dir))
 
 
 def teardown_module():
     """Cleanup temporary output files after testing and return to root directory"""
-    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    os.chdir(retriever_root_dir)
     os.system("rm -r output*")
     os.system("rm -r raw_data/mom2003")
     os.system("rm -r raw_data/EA*")
     os.system("rm testdb.sqlite")
-    os.chdir("..")
 
 
 @pytest.mark.parametrize("dataset, expected", db_md5)
@@ -116,11 +111,8 @@ def test_csv_regression(dataset, expected, tmpdir):
 
 @pytest.mark.parametrize("dataset, expected", download_md5)
 def test_download_regression(dataset, expected):
-    """Check for regression for a particular dataset downloaded only
-
-    "Move the dataset script to the .retriever directory before download."
-    """
-    os.system('cp -r {0} {1}'.format(os.path.join(parent, "scripts"), os.path.join(HOMEDIR, '.retriever')))
+    """Check for regression for a particular dataset downloaded only"""
+    os.chdir(retriever_root_dir)
     os.system("retriever download {0} -p raw_data/{0}".format(dataset))
     current_md5 = getmd5(data="raw_data/{0}".format(dataset), data_type='dir', mode="rU")
     assert current_md5 == expected

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -1,16 +1,14 @@
 """Tests for the Data Retriever"""
 from future import standard_library
-standard_library.install_aliases()
-from imp import reload
-from future.builtins import input
 
+standard_library.install_aliases()
 import os
-import pytest
 import sys
+from imp import reload
+
 reload(sys)
 if hasattr(sys, 'setdefaultencoding'):
     sys.setdefaultencoding('utf-8')
-from io import StringIO
 from retriever.lib.engine import Engine
 from retriever.lib.table import Table
 from retriever.lib.templates import BasicTextTemplate
@@ -195,7 +193,7 @@ def test_getmd5_lines():
 def test_getmd5_path():
     """Test md5 sum calculation given a path to data source"""
     data_file = create_file('a,b,c\n1,2,3\n4,5,6\n')
-    assert getmd5(data=data_file, data_type='file',mode='rU') == '0bec5bf6f93c547bc9c6774acaf85e1a'
+    assert getmd5(data=data_file, data_type='file', mode='rU') == '0bec5bf6f93c547bc9c6774acaf85e1a'
 
 
 def test_json2csv():
@@ -246,101 +244,117 @@ def test_sort_csv():
 
 def test_is_empty_null_string():
     """Test for null string"""
-    assert(is_empty("") == True)
+    assert is_empty("") == True
 
 
 def test_is_empty_empty_list():
     """Test for empty list"""
-    assert(is_empty([]) == True)
+    assert is_empty([]) == True
 
 
 def test_is_empty_not_null_string():
     """Test for non-null string"""
-    assert(is_empty("not empty") == False)
+    assert is_empty("not empty") == False
 
 
 def test_is_empty_not_empty_list():
     """Test for not empty list"""
-    assert(is_empty(["not empty"]) == False)
+    assert is_empty(["not empty"]) == False
 
 
 def test_clean_input_empty_input_ignore_empty(monkeypatch):
     """Test with empty input ignored"""
+
     def mock_input(prompt):
         return ""
+
     monkeypatch.setattr('retriever.lib.datapackage.input', mock_input)
-    assert(clean_input("", ignore_empty=True) == "")
+    assert clean_input("", ignore_empty=True) == ""
 
 
 def test_clean_input_empty_input_not_ignore_empty(monkeypatch):
     """Test with empty input not ignored"""
+
     def mock_input(prompt):
         mock_input.counter += 1
         if mock_input.counter <= 1:
             return ""
         else:
             return "not empty"
+
     mock_input.counter = 0
     monkeypatch.setattr('retriever.lib.datapackage.input', mock_input)
-    assert(clean_input("", ignore_empty=False) == "not empty")
+    assert clean_input("", ignore_empty=False) == "not empty"
 
 
 def test_clean_input_string_input(monkeypatch):
     """Test with non-empty input"""
+
     def mock_input(prompt):
         return "not empty"
+
     monkeypatch.setattr('retriever.lib.datapackage.input', mock_input)
-    assert(clean_input("") == "not empty")
+    assert clean_input("") == "not empty"
 
 
 def test_clean_input_empty_list_ignore_empty(monkeypatch):
     """Test with empty list ignored"""
+
     def mock_input(prompt):
         return ",  ,   ,"
+
     monkeypatch.setattr('retriever.lib.datapackage.input', mock_input)
-    assert(clean_input("", ignore_empty=True, split_char=",") == [])
+    assert clean_input("", ignore_empty=True, split_char=",") == []
 
 
 def test_clean_input_empty_list_not_ignore_empty(monkeypatch):
     """Test with empty list not ignored"""
+
     def mock_input(prompt):
         mock_input.counter += 1
         if mock_input.counter <= 1:
             return ",  ,   ,"
         else:
             return "1  ,    2,  3,"
+
     mock_input.counter = 0
     monkeypatch.setattr('retriever.lib.datapackage.input', mock_input)
-    assert(clean_input("", split_char=",") == ["1", "2", "3"])
+    assert clean_input("", split_char=",") == ["1", "2", "3"]
 
 
 def test_clean_input_not_empty_list(monkeypatch):
     """Test with list input"""
+
     def mock_input(prompt):
         return "1,    2,     3"
+
     monkeypatch.setattr('retriever.lib.datapackage.input', mock_input)
-    assert(clean_input("", ignore_empty=True, split_char=',', dtype=None) == ["1", "2", "3"])
+    assert clean_input("", ignore_empty=True, split_char=',', dtype=None) == ["1", "2", "3"]
 
 
 def test_clean_input_bool(monkeypatch):
     """Test with correct datatype input"""
+
     def mock_input(prompt):
         return "True "
+
     monkeypatch.setattr('retriever.lib.datapackage.input', mock_input)
-    assert(clean_input("", dtype=bool) == "True")
+    assert clean_input("", dtype=bool) == "True"
 
 
 def test_clean_input_not_bool(monkeypatch):
     """Test with incorrect datatype input"""
+
     def mock_input(prompt):
         mock_input.counter += 1
         if mock_input.counter <= 1:
             return "non bool input"
         else:
             return "True "
+
     mock_input.counter = 0
     monkeypatch.setattr('retriever.lib.datapackage.input', mock_input)
-    assert(clean_input("", dtype=bool) == "True")
+    assert clean_input("", dtype=bool) == "True"
 
 
 def test_add_dialect():

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -30,16 +30,19 @@ test_engine.script = BasicTextTemplate(tables={'test': test_engine.table},
                                        shortname='test')
 test_engine.opts = {'database_name': '{db}_abc'}
 HOMEDIR = os.path.expanduser('~')
+file_location = os.path.dirname(os.path.realpath(__file__))
+retriever_root_dir = os.path.abspath(os.path.join(file_location, os.pardir))
 
 
 def setup_module():
-    """"change directory to test directory"""
-    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    """"Make sure you are in the main local retriever directory"""
+    os.chdir(retriever_root_dir)
+    os.system('cp -r {0} {1}'.format(os.path.join(retriever_root_dir, "test/raw_data"), retriever_root_dir))
 
 
 def teardown_method():
-    """Cleanup temporary output files after testing"""
-    os.chdir("..")
+    """Make sure you are in the main local retriever directory after these tests"""
+    os.chdir(retriever_root_dir)
 
 
 def test_auto_get_columns():
@@ -139,10 +142,9 @@ def test_find_file_absent():
 def test_find_file_present():
     """Test if existing datafile is found
 
-    Using the AvianBodySize dataset which is included for regression testing
-    Because all testing code and data is located in ./test/ it is necessary to
-    move into this directory for DATA_SEARCH_PATHS to work properly.
-
+    Using the AvianBodySize dataset which is included for regression testing.
+    We copy the raw_data directory to retriever_root_dir which is the current working directory.
+    This enables the data to be in the DATA_SEARCH_PATHS.
     """
     test_engine.script.shortname = 'AvianBodySize'
     assert test_engine.find_file('avian_ssd_jan07.txt') == os.path.normpath(


### PR DESCRIPTION
The previous version of tests updated scripts
fetching the master `scripts` and then
used the updated scripts for testing

This commit ensures that the retriever used the local script directory.
we get the `scripts` directory using the path of the test module location.