### PR TITLE
Make sure temporary `raw_data` test directory is removed

### DIFF
--- a/test/test_regression_cli.py
+++ b/test/test_regression_cli.py
@@ -3,6 +3,7 @@ from imp import reload
 import imp
 import os
 import sys
+import shutil
 
 reload(sys)
 if hasattr(sys, 'setdefaultencoding'):
@@ -57,8 +58,7 @@ def teardown_module():
     """Cleanup temporary output files after testing and return to root directory"""
     os.chdir(retriever_root_dir)
     os.system("rm -r output*")
-    os.system("rm -r raw_data/mom2003")
-    os.system("rm -r raw_data/EA*")
+    shutil.rmtree(os.path.join(retriever_root_dir, "raw_data"))
     os.system("rm testdb.sqlite")
 
 

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -4,6 +4,7 @@ from future import standard_library
 standard_library.install_aliases()
 import os
 import sys
+import shutil
 from imp import reload
 
 reload(sys)
@@ -40,9 +41,10 @@ def setup_module():
     os.system('cp -r {0} {1}'.format(os.path.join(retriever_root_dir, "test/raw_data"), retriever_root_dir))
 
 
-def teardown_method():
+def teardown_module():
     """Make sure you are in the main local retriever directory after these tests"""
     os.chdir(retriever_root_dir)
+    shutil.rmtree(os.path.join(retriever_root_dir, "raw_data"))
 
 
 def test_auto_get_columns():


### PR DESCRIPTION
Starting with the merge of #626 we create a copy of the `test/raw_data` directory
in the root directory for testing. It wasn't getting properly cleaned up by all,
of the test modules. This fixes that and replaces a couple `os.system("rm -r...")
calls with a better `shutil.rmtree`.