### PR TITLE
Add encoding information to compiled python files

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -78,7 +78,7 @@ def MODULE_LIST(force_compile=False):
 
         files = [file for file in os.listdir(search_path)
                  if file[-3:] == ".py" and file[0] != "_" and
-                 '#retriever' in open(join(search_path, file), 'r').readline().lower()]
+                 '#retriever' in ' '.join(open(join(search_path, file), 'r').readlines()[:2]).lower()]
 
         for script in files:
             script_name = '.'.join(script.split('.')[:-1])

--- a/lib/compile.py
+++ b/lib/compile.py
@@ -1,5 +1,9 @@
 from builtins import str
 import json
+import sys
+if sys.version_info[0] < 3:
+    from codecs import open
+
 script_templates = {
     "default": """#retriever
 from retriever.lib.templates import BasicTextTemplate
@@ -287,6 +291,7 @@ def compile_json(json_file):
         template = "default"
     script_contents = (script_templates[template] % script_desc)
 
-    new_script = open(json_file + '.py', 'w')
+    new_script = open(json_file + '.py', 'w', encoding='utf-8')
+    new_script.write('# -*- coding: latin-1 -*-\n')
     new_script.write(script_contents)
     new_script.close()


### PR DESCRIPTION
Required to load python scripts having non-ASCII characters in Python 2.

Relevent SO post: http://stackoverflow.com/questions/33255846/python-write-a-list-with-non-ascii-characters-to-a-text-file

Closes #640 