### PR TITLE
Change progress output

### DIFF
--- a/lib/engine.py
+++ b/lib/engine.py
@@ -159,9 +159,10 @@ class Engine(object):
                         self.execute(insert_stmt, commit=False)
                         current += insert_limit
                         if current > real_line_length:
-                            print(str(real_line_length) + " rows inserted into " + self.table_name() + ": ")
+                            prompt = str(real_line_length) + " / " + str(total) + " rows inserted into " + self.table_name() + ": "
                         else:
-                            print(str(current) + " rows inserted into " + self.table_name() + ": ")
+                            prompt = str(current) + " / " + str(total) + " rows inserted into " + self.table_name() + ": "
+                        sys.stdout.write(prompt + "\b" * len(prompt))
                     except:
                         print(insert_stmt)
                         raise


### PR DESCRIPTION
The current status prints progress on a new line.
This was introduced in commit 3002c19 and we and changing to
the previous style of priniting.