### PR TITLE
Add code of conduct

### DIFF
--- a/docs/code_of_conduct.rst
+++ b/docs/code_of_conduct.rst
@@ -1,0 +1,54 @@
+Contributor Code of Conduct
+===========================
+
+
+Our Pledge
+^^^^^^^^^^
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+Our Standards
+^^^^^^^^^^^^^
+
+Examples of behavior that contributes to creating a positive environment include:
+
+Using welcoming and inclusive language
+Being respectful of differing viewpoints and experiences
+Gracefully accepting constructive criticism
+Focusing on what is best for the community
+Showing empathy towards other community members
+Examples of unacceptable behavior by participants include:
+
+The use of sexualized language or imagery and unwelcome sexual attention or advances
+Trolling, insulting/derogatory comments, and personal or political attacks
+Public or private harassment
+Publishing others' private information, such as a physical or electronic address, without explicit permission
+Other conduct which could reasonably be considered inappropriate in a professional setting
+
+Our Responsibilities
+^^^^^^^^^^^^^^^^^^^^
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+Scope
+^^^^^
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+Enforcement
+^^^^^^^^^^^
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at `ethan@weecology.org
+<mailto:ethan@weecology.org>`__. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+Attribution
+^^^^^^^^^^^
+
+This Code of Conduct is adapted from the  `Contributor Covenant, version 1.4`_.
+
+
+.. _Contributor Covenant, version 1.4: http://contributor-covenant.org/version/1/4

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,13 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from imp import reload
+import sys
+# sys removes the setdefaultencoding method at startup; reload to get it back
+reload(sys)
+if hasattr(sys, 'setdefaultencoding'):
+    # set default encoding to latin-1 to decode source text
+    sys.setdefaultencoding('latin-1')
+
 from builtins import str
 from retriever import VERSION,COPYRIGHT
 from retriever.lib.repository import check_for_updates

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Contents:
    macbuild.rst
    Release.rst
    developer.rst
+   code_of_conduct.rst
    ecoretriever.rst
    datasets.rst
    modules.rst

--- a/try_install_all.py
+++ b/try_install_all.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import os
 import sys
-from importlib import reload
+from imp import reload
 from retriever.lib.tools import choose_engine
 from retriever import MODULE_LIST, ENGINE_LIST, SCRIPT_LIST
 


### PR DESCRIPTION
This code of conduct has been adapted from the
Contributor Covenant, version 1.4: http://contributor-covenant.org/version/1/4.

This commit also sets the encoding for for the conf.py module
and adds __future__ libraries required for python3
fixes #654