### PR TITLE
Allow `reload` to work in Python 3 in `try_install_all.py`

### DIFF
--- a/try_install_all.py
+++ b/try_install_all.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import os
 import sys
+from importlib import reload
 from retriever.lib.tools import choose_engine
 from retriever import MODULE_LIST, ENGINE_LIST, SCRIPT_LIST
 


### PR DESCRIPTION
In Python 3 `reload` is not present by default and needs to be imported.
This adds that import to `try_install_all.py` so that it works with Python 3.