### PR TITLE
Repairs GWDD dataset.

### DIFF
--- a/scripts/gwdd.py
+++ b/scripts/gwdd.py
@@ -117,7 +117,8 @@ class main(Script):
         self.engine.table = table
         self.engine.create_table()
         self.engine.add_to_table(data)
-        
+        self.engine.find_file("GlobalWoodDensityDatabase.xls")
+
         return self.engine
 
 SCRIPT = main()


### PR DESCRIPTION
The dataset script could not perform a correct `retriever download gwdd` because the file was
not added to the list of all expected files. Using `engine.find_file()`
adds the file to the set of all files expected to be downloaded.

fixes #675