### PR TITLE
Overwrite create_db for download engine

### DIFF
--- a/engines/download_only.py
+++ b/engines/download_only.py
@@ -138,7 +138,7 @@ keep_methods = {'table_exists',
                 'auto_create_table',
                 'insert_data_from_url',
                 }
-remove_methods = ['insert_data_from_file']
+remove_methods = ['insert_data_from_file', 'create_db']
 for name, method in methods:
     if (name not in keep_methods and
             'download' not in name and


### PR DESCRIPTION
This removes unnecessary warning when using `download`
fixes #667