### PR TITLE
Remove urlretrieve import from python 2

### DIFF
--- a/lib/engine.py
+++ b/lib/engine.py
@@ -16,10 +16,7 @@ import gzip
 import tarfile
 import csv
 import io
-if sys.version_info[0] >= 3:
-    from urllib.request import urlretrieve
-else:
-    from urllib import urlretrieve
+from urllib.request import urlretrieve
 from retriever import DATA_SEARCH_PATHS, DATA_WRITE_PATH
 from retriever.lib.cleanup import no_cleanup
 from retriever.lib.warning import Warning


### PR DESCRIPTION
Why?
`urlretrieve` function in Python 2 is buggy and returns [Error 200] while downloading archives, maybe because of a socket-closing issue.

Fix:
This issue is not present when using the `future` package, which backports urllib from Python 3.
Using future.standard_library.install_aliases, the Python 3 API with the backports is made available in Python 2.

Fixes #705 