### PR TITLE
Update docs for releases

### DIFF
--- a/docs/Release.rst
+++ b/docs/Release.rst
@@ -6,7 +6,7 @@ Start
 -----
 
 1. **Run the tests**. Seriously, do it now.
-2. In the `master` branch update the version number in ``__init__.py`` (if it
+2. In the `master` branch update the version number in ``setup.py`` (if it
    hasn’t already been bumped)
 3. Run ``python version.py`` (this will update ``version.txt``)
 4. Update the version number in ``retriever_installer.iss`` (if it

--- a/docs/Release.rst
+++ b/docs/Release.rst
@@ -6,11 +6,8 @@ Start
 -----
 
 1. **Run the tests**. Seriously, do it now.
-2. In ``__init__.py`` in master
-
-   1. Update the version number (if it hasn’t already been bumped)
-   2. Change ``MASTER = True`` to ``MASTER = False``
-
+2. In the `master` branch update the version number in ``__init__.py`` (if it
+   hasn’t already been bumped)
 3. Run ``python version.py`` (this will update ``version.txt``)
 4. Update the version number in ``retriever_installer.iss`` (if it
    hasn’t already been bumped)


### PR DESCRIPTION
1. Having updated how we handle scripts (see #318) the MASTER variable
has been removed and no longer needs to be changed before releasing.
2. The version number is now stored in setup.py

Fixes #710.