### PR TITLE
Follow up PR: Fixed formatting in Iris.json and removed redundant data

### DIFF
--- a/lib/compile.py
+++ b/lib/compile.py
@@ -107,6 +107,9 @@ def compile_json(json_file):
         elif key == "description":
             values["description"] = "\"" + str(value) + "\""
 
+        elif key == "addendum":
+            values["addendum"] = "\"" + str(value) + "\""
+
         elif key == "homepage":
             values["ref"] = "\"" + str(value) + "\""
 

--- a/scripts/Iris.json
+++ b/scripts/Iris.json
@@ -1,8 +1,6 @@
 {
-    "citation": "R. A. Fisher. 1936. The Use of Multiple Measurements in Taxonomic Problems. and Asuncion, A. & Newman, D.J. (2007). UCI Machine Learning Repository [http://www.ics.uci.edu/~mlearn/MLRepository.html]. Irvine, CA: University of California, School of Information and Computer Science.
-
-",
-    "description": "Famous dataset from R. A. Fisher",
+    "citation": "R. A. Fisher. 1936. The Use of Multiple Measurements in Taxonomic Problems. and Asuncion, A. & Newman, D.J. (2007). UCI Machine Learning Repository [http://www.ics.uci.edu/~mlearn/MLRepository.html]. Irvine, CA: University of California, School of Information and Computer Science.",
+    "description": "Famous dataset from R. A. Fisher. This dataset has been corrected. Information Source: Asuncion, A. & Newman, D.J. (2007). UCI Machine Learning Repository [http://www.ics.uci.edu/~mlearn/MLRepository.html]. Irvine, CA: University of California, School of Information and Computer Science.",
     "homepage": "http://mlr.cs.umass.edu/ml/datasets/Iris",
     "keywords": [
         "Taxon > Plants",
@@ -41,39 +39,6 @@
                     }
                 ]
             },
-            "url": "http://mlr.cs.umass.edu/ml/machine-learning-databases/iris/iris.data"
-        }, 
-        {
-            "dialect": {
-                "delimiter": ",",
-                "header_rows": 0
-            },
-            "name": "bezdekIris",
-            "schema": {
-                "fields": [
-                    {
-                        "name": "sepal_length",
-                        "type": "double"
-                    },
-                    {
-                        "name": "sepal_width",
-                        "type": "double"
-                    },
-                    {
-                        "name": "petal_length",
-                        "type": "double"
-                    },
-                    {
-                        "name": "petal_width",
-                        "type": "double"
-                    },
-                    {
-                        "name": "class",
-                        "size": "20",
-                        "type": "char"
-                    }
-                ]
-            },
             "url": "http://mlr.cs.umass.edu/ml/machine-learning-databases/iris/bezdekIris.data"
         }
     ],
@@ -81,8 +46,7 @@
     "retriever_minimum_version": "2.0.dev",
     "title": "Iris Plants Database",
     "urls": {
-        "Iris": "http://mlr.cs.umass.edu/ml/machine-learning-databases/iris/iris.data",
-        "bezdekIris": "http://mlr.cs.umass.edu/ml/machine-learning-databases/iris/bezdekIris.data"
+        "Iris": "http://mlr.cs.umass.edu/ml/machine-learning-databases/iris/bezdekIris.data"
     },
-    "version": 1.0
+    "version": 1.1
 }


### PR DESCRIPTION
Fixed some formatting in Iris.json. Also the script only downloads the
bezdekIris dataset now, which is the corrected dataset.


Should the version number for the script be 1.0 or 1.1? 