### PR TITLE
Fix a data entry/formatting error in Gentry

### DIFF
--- a/scripts/gentry.py
+++ b/scripts/gentry.py
@@ -25,7 +25,7 @@ class main(Script):
         self.name = "Alwyn H. Gentry Forest Transect Dataset"
         self.shortname = "Gentry"
         self.retriever_minimum_version = '2.0.dev'
-        self.version = '1.1'
+        self.version = '1.2'
         self.urls = {"stems": "http://www.mobot.org/mobot/gentry/123/all_Excel.zip",
                      "sites": "https://ndownloader.figshare.com/files/5515373",
                      "species": "",
@@ -121,6 +121,13 @@ U.S.A. """
                                               for c in cn["stems"]
                                               if not Excel.empty_cell(row[c])]
                         this_line["site"] = filename[0:-4]
+
+                        # Manually correct CEDRAL data, which has a single line
+                        # that is shifted by one to the left starting at Liana
+                        if this_line["site"] == "CEDRAL" and type(this_line["liana"]) == float:
+                            this_line["liana"] = ""
+                            this_line["count"] = 3
+                            this_line["stems"] = [2.5, 2.5, 30, 18, 25]
 
                         lines.append(this_line)
 


### PR DESCRIPTION
On line 130 of the CEDRAL data there is an extra ' in the voucher1 column.
This is related to a parsing error in the raw Excel file that makes all
following columns off by one, which results in the Counts column containing
non-integer values (because the first size ends up in the counts column)
and the stems table will be missing a single, 2.5, value.

This fix finds that row and then manually updates the relevant values to the
correct ones.

Fixes #415.