### PR TITLE
Fix JSON and XML encoding issues on *nix Python 3

### DIFF
--- a/engines/jsonengine.py
+++ b/engines/jsonengine.py
@@ -70,7 +70,7 @@ class engine(Engine):
         if self.table_names:
             for output_file_i, file_name in self.table_names:
                 output_file_i.close()
-                current_input_file = open_fr(file_name, encode=False)
+                current_input_file = open_fr(file_name)
                 file_contents = current_input_file.readlines()
                 current_input_file.close()
                 file_contents[-1] = file_contents[-1].strip(',\n')

--- a/engines/xmlengine.py
+++ b/engines/xmlengine.py
@@ -68,7 +68,7 @@ class engine(Engine):
         if self.table_names:
             for output_file_i, file_name in self.table_names:
                 output_file_i.close()
-                current_input_file = open_fr(file_name, encode=False)
+                current_input_file = open_fr(file_name)
                 file_contents = current_input_file.readlines()
                 current_input_file.close()
                 file_contents[-1] = file_contents[-1].strip(',')

--- a/lib/tools.py
+++ b/lib/tools.py
@@ -169,7 +169,7 @@ def json2csv(input_file, output_file=None, header_values=None):
     """Convert Json file to CSV
     function is used for only testing and can handle the file of the size
     """
-    file_out = open_fr(input_file)
+    file_out = open_fr(input_file, encode = False)
     # set output file name and write header
     if output_file is None:
         output_file = os.path.splitext(os.path.basename(input_file))[0] + ".csv"


### PR DESCRIPTION
During disconnect files were being read without latin-1 encoding causing
an error before when they were read before disconnected.