### PR TITLE
Fix for missing values in XML engine.

### DIFF
--- a/engines/xmlengine.py
+++ b/engines/xmlengine.py
@@ -108,15 +108,11 @@ class engine(Engine):
         else:
             newrows = values
 
-        open_tag = '\n<row>\n'
-        end_tag = '</row>'
-        xml_lines = []
-        for line_data in newrows:
-            write_data = ""
-            for i in range(len(keys)):
-                write_data += '    ' + '<' + str(keys[i]) + '>' + str(line_data[i]) + '</' + str(keys[i]) + '>' + "\n"
-            xml_lines.append(open_tag + write_data + end_tag)
+        xml_lines = ['\n<row>\n{}</row>'.format(self._format_single_row(keys, line_data)) for line_data in newrows]
         return xml_lines
+
+    def _format_single_row(self, keys, line_data):
+        return ''.join('    <{key}>{value}</{key}>\n'.format(key=key, value=value) for key, value in zip(keys, line_data))
 
     def table_exists(self, dbname, tablename):
         """Check to see if the data file currently exists"""

--- a/lib/table.py
+++ b/lib/table.py
@@ -128,6 +128,12 @@ class Table(object):
                 # too many values for columns; ignore
                 pass
             column += 1
+
+        # make sure we have enough values by padding with None
+        keys = self.get_insert_columns(join=False, create=False)
+        if len(linevalues) < len(keys):
+            linevalues.extend([None for _ in range(len(keys) - len(linevalues))])
+
         return linevalues
 
     def get_insert_columns(self, join=True, create=False):


### PR DESCRIPTION
This fixes an issue with Palmer2007 which currently fails with an IndexError. The issue is that the raw data file is missing values for "check" and "notes" in many rows.

The fix pads the row with empty values when a row is shorter than the header row. This happens to work for this dataset (where missing values are always at the end of the row) and is consistent with the sqlite engine's behavior, which fills in NULLs. However, there does seem to be some danger of masking legitimate data issues that the current strictness would help catch.