### PR TITLE
Make script search paths work in correct order

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -124,6 +124,7 @@ def to_str(object, object_encoding=sys.stdout):
 def MODULE_LIST(force_compile=False):
     """Load scripts from scripts directory and return list of modules."""
     modules = []
+    loaded_scripts = []
 
     for search_path in [search_path for search_path in SCRIPT_SEARCH_PATHS if exists(search_path)]:
         to_compile = [
@@ -143,10 +144,11 @@ def MODULE_LIST(force_compile=False):
 
         for script in files:
             script_name = '.'.join(script.split('.')[:-1])
-            file, pathname, desc = imp.find_module(script_name, [search_path])
-            try:
-                new_module = imp.load_module(script_name, file, pathname, desc)
-                if new_module not in modules:
+            if script_name not in loaded_scripts:
+                loaded_scripts.append(script_name)
+                file, pathname, desc = imp.find_module(script_name, [search_path])
+                try:
+                    new_module = imp.load_module(script_name, file, pathname, desc)
                     if hasattr(new_module.SCRIPT, "retriever_minimum_version"):
                         # a script with retriever_minimum_version should be loaded
                         # only if its compliant with the version of the retriever
@@ -160,10 +162,9 @@ def MODULE_LIST(force_compile=False):
                     # make sure it works and then add it
                     new_module.SCRIPT.download
                     modules.append(new_module)
-            except Exception as e:
-                sys.stderr.write("Failed to load script: %s (%s)\nException: %s \n" % (
-                    script_name, search_path, str(e)))
-
+                except Exception as e:
+                    sys.stderr.write("Failed to load script: %s (%s)\nException: %s \n" % (
+                        script_name, search_path, str(e)))
     return modules
 
 


### PR DESCRIPTION
The design is to look for scripts first in ., then in ./scripts, and finally
in ~/.retriever/scripts. The first script found should be loaded and any additional
copies of the same script ignored. The previously implementation looked good, but had
issues with aliasing, so even though copies of scripts from later directories weren't
explicitly added, they were replacing the correct scripts in the list. This separates
the check for whether the script has already been found to avoid the aliasing issue.

This design allows for easy development and customization. When developing modified
scripts in the repository are used by default. When customizing scripts added to
the working directory are used preferentially. When no other scripts appear the core
scripts are used.

This solves the painful development issue of needing to repeatedly run `retriever reset scripts` to avoid potentially testing outdated scripts in `~/.retriever` instead of the modified scripts in the repository.