### PR TITLE
Reset home-ranges version to proper value

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -20,7 +20,7 @@ forest-plots-michigan.json,1.1.0
 forest-plots-wghats.json,1.1.0
 fray-jorge-ecology.json,1.2.0
 gentry-forest-transects.py,1.3.0
-home-ranges.json,1.2.0
+home-ranges.json,1.1.0
 intertidal-abund-me.py,1.3.0
 iris.json,1.2.0
 la-selva-trees.py,1.2.0


### PR DESCRIPTION
A change to the home-ranges version number in version.txt crept in in
852830e even though now change to the script or its version was made.
This resets the version in version.txt to the proper value.