### PR TITLE
Update README to match renaming for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ optional arguments:
 
 
 ###Examples
+
 ```
-These examples are using Breeding Bird Survey data (BBS)
+These examples are using the [*Iris* flower dataset](https://en.wikipedia.org/wiki/Iris_flower_data_set).
 
 Using Install
 
@@ -129,21 +130,21 @@ Using Install
 Using specific database engine, retriever install {Engine}
 
   retriever install mysql -h     (gives install mysql options)
-  retriever install mysql --user myuser --password ******** --host localhost --port 8888 --database_name testdbase BBS
+  retriever install mysql --user myuser --password ******** --host localhost --port 8888 --database_name testdbase iris
 
 install data into an sqlite database named mydatabase.db you would use:
 
-  retriever install sqlite BBS -f mydatabase.db
+  retriever install sqlite iris -f iris.sqlite
 
 Using download
 
   retriever download -h    (gives you help options)
-  retriever download BBS"
-  retriever download BBS --path C:\Users\Documents
+  retriever download iris
+  retriever download iris --path C:\Users\Documents
 
 Using citation
   retriever citation   (citation of the retriever engine)
-  retriever citation BBS   (citation of BBS data)
+  retriever citation iris  (citation for the iris data)
   ```
 
 Website


### PR DESCRIPTION
This also switches to using the iris data so that the examples will run
quickly and the dataset will be familiar to the widest group of users.

Fixes #777.