### PR TITLE
Fix 778: Update version.py to run in python 2

### DIFF
--- a/version.py
+++ b/version.py
@@ -4,24 +4,29 @@ import os
 from retriever import VERSION, MODULE_LIST
 
 
+def get_module_version():
+    """This function gets the version number of the scripts and returns them in array form."""
+    modules = MODULE_LIST()
+    scripts = []
+    for module in modules:
+        if module.SCRIPT.public:
+            if os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.json') and module.SCRIPT.version:
+                module_name = module.__name__ + '.json'
+                scripts.append(','.join([module_name, str(module.SCRIPT.version)]))
+            elif os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.py') and \
+                    not os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.json'):
+                module_name = module.__name__ + '.py'
+                scripts.append(','.join([module_name, str(module.SCRIPT.version)]))
+
+    scripts = sorted(scripts, key = str.lower)
+    return scripts
+
+scripts = get_module_version()
+
 if os.path.isfile("version.txt"):
     os.remove("version.txt")
-version_file = open("version.txt", "w")
-version_file.write(VERSION)
-modules = MODULE_LIST()
-scripts = []
-for module in modules:
-    if module.SCRIPT.public:
-        if os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.json') and module.SCRIPT.version:
-            module_name = module.__name__ + '.json'
-            scripts.append(','.join([module_name, str(module.SCRIPT.version)]))
-        elif os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.py') and \
-                not os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.json'):
-            module_name = module.__name__ + '.py'
-            scripts.append(','.join([module_name, str(module.SCRIPT.version)]))
 
-scripts = sorted(scripts, key = str.casefold)
-
-for script in scripts:
-    version_file.write('\n' + script)
-version_file.close()
+with open("version.txt", "w") as version_file:
+    version_file.write(VERSION)
+    for script in scripts:
+        version_file.write('\n' + script)

--- a/version.txt
+++ b/version.txt
@@ -20,7 +20,7 @@ forest-plots-michigan.json,1.1.0
 forest-plots-wghats.json,1.1.0
 fray-jorge-ecology.json,1.2.0
 gentry-forest-transects.py,1.3.0
-home-ranges.json,1.2.0
+home-ranges.json,1.1.0
 intertidal-abund-me.py,1.3.0
 iris.json,1.2.0
 la-selva-trees.py,1.2.0


### PR DESCRIPTION
`version.py` restructured and `casefold` attribute changed to `lower`. `version.py` has been rerun changing the `version.txt` and getting the right json version for `home-ranges.json` which is `1.1.0`.