### PR TITLE
Use pyinstaller for creating exe for windows and app for mac

### DIFF
--- a/build_mac
+++ b/build_mac
@@ -1,13 +1,7 @@
 export DYLD_LIBRARY_PATH=/usr/local/mysql/lib/
 sudo rm -rf mac
+sudo mkdir mac
 sudo python setup.py install
-sudo python setup.py py2app
-sudo mv dist mac
-sudo rm mac/*.egg
-sudo rm -rf mac/scripts
-sudo ditto --rsrc x86_64 mac/retriever.app mac/retriever2.app
-sudo rm -rf mac/retriever.app
-sudo mv mac/retriever2.app mac/retriever.app
-cd mac
-sudo zip -r retriever.zip retriever.app
-cd ..
+sudo pyinstaller pyinstaller.spec --log-level ERROR
+sudo mv dist/retriever.app mac/retriever.app
+sudo rm -rf build dist

--- a/build_win
+++ b/build_win
@@ -4,7 +4,7 @@ rm -rf build dist
 mkdir packages
 
 #create distributable version
-python setup.py py2exe
+pyinstaller pyinstaller.spec
 
 #package distributable installer
 ISCC.exe retriever_installer.iss

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -1,0 +1,72 @@
+# -*- mode: python -*-
+import os
+import distutils.util
+
+platform = distutils.util.get_platform()
+block_cipher = None
+
+a = Analysis(['__main__.py'],
+             pathex=['.', 'lib','engines', 'scripts'],
+             binaries=[],
+             datas=[],
+             hiddenimports=['xlrd', 'pymysql', 'psycopg2', 'sqlite3', 'pyodbc'],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[
+                       ],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+
+a.pure += [('retriever.engines.mysql','engines/mysql.py','PYMODULE'),
+           ('retriever.engines.postgres','engines/postgres.py', 'PYMODULE'),
+           ('retriever.engines.sqlite','engines/sqlite.py', 'PYMODULE'),
+           ('retriever.engines.msaccess','engines/msaccess.py', 'PYMODULE'),
+           ('retriever.engines.csvengine','engines/csvengine.py', 'PYMODULE'),
+           ('retriever.engines.download_only','engines/download_only.py', 'PYMODULE'),
+           ('retriever.engines.jsonengine','engines/jsonengine.py', 'PYMODULE'),
+           ('retriever.engines.xmlengine','engines/xmlengine.py', 'PYMODULE'),
+           ('retriever.lib.templates', 'lib/templates.py', 'PYMODULE'),
+           ('retriever.lib.excel', 'lib/excel.py', 'PYMODULE')]
+
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+
+icon_file='icon.ico'
+if 'macosx' in platform:
+    icon_file='osx_icon.icns'
+
+if 'macosx' or 'linux' in platform:
+    exe = EXE(pyz,
+            a.scripts,
+            a.binaries,
+            a.zipfiles,
+            a.datas,
+            name='retriever',
+            debug=False,
+            strip=False,
+            upx=True,
+            console=False , icon=icon_file)
+
+if 'macosx' in platform:
+    app = BUNDLE(exe,
+               name='retriever.app',
+               icon='osx_icon.icns',
+               bundle_identifier=None)
+
+if 'win' in platform:
+    exe = EXE(pyz,
+              a.scripts,
+              exclude_binaries=True,
+              name='retriever',
+              debug=False,
+              strip=False,
+              upx=True,
+              console=True,  icon=icon_file )
+    coll = COLLECT(exe,
+                   a.binaries,
+                   a.zipfiles,
+                   a.datas,
+                   strip=False,
+                   upx=True,
+                   name='packages')

--- a/retriever_installer.iss
+++ b/retriever_installer.iss
@@ -28,8 +28,8 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Name: modifypath; Description: Add application directory to your environmental path
 
 [Files]
-Source: "dist\retriever.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "dist\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "dist\packages\retriever.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "dist\packages\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/setup.py
+++ b/setup.py
@@ -8,21 +8,6 @@ import platform
 
 current_platform = platform.system().lower()
 extra_includes = []
-if current_platform == "darwin":
-    try:
-        import py2app
-    except ImportError:
-        pass
-    extra_includes = []
-elif current_platform == "windows":
-    try:
-        import py2exe
-    except ImportError:
-        pass
-    import sys
-    extra_includes = ['pyodbc', 'inspect']
-    sys.path.append(
-        "C:\\Windows\\winsxs\\x86_microsoft.vc90.crt_1fc8b3b9a1e18e3b_9.0.21022.8_none_bcb86ed6ac711f91")
 
 __version__ = 'v2.0.dev'
 with open("_version.py", "w") as version_file:
@@ -50,17 +35,12 @@ includes = [
 excludes = [
     'pyreadline',
     'doctest',
-    'optparse',
-    'getopt',
     'pickle',
-    'calendar',
     'pdb',
-    'inspect',
-    'email',
     'pywin', 'pywin.debugger',
     'pywin.debugger.dbgcon',
     'pywin.dialogs', 'pywin.dialogs.list',
-    'Tkconstants', 'Tkinter', 'tcl',
+    'Tkconstants', 'Tkinter', 'tcl', 'tk'
 ]
 
 setup(name='retriever',
@@ -88,39 +68,10 @@ setup(name='retriever',
           'future'
       ],
 
-      # py2exe flags
-      console=[{'script': "__main__.py",
-                'dest_base': "retriever",
-                'icon_resources': [(1, 'icon.ico')]
-                }],
-      zipfile=None,
-
       # py2app flags
       app=['__main__.py'],
       data_files=[('', ['CITATION'])],
-      setup_requires=['py2app'] if current_platform == 'darwin' else [],
-
-      # options
-      # optimize is set to 1 of py2app to avoid errors with pymysql
-      # bundle_files = 1 or 2 was causing failed builds so we moved
-      # to bundle_files = 3 and Inno Setup
-      options={'py2exe': {'bundle_files': 3,
-                          'compressed': 2,
-                          'optimize': 1,
-                          'packages': packages,
-                          'includes': includes,
-                          'excludes': excludes,
-                          },
-               'py2app': {'packages': ['retriever'],
-                          'includes': includes,
-                          'site_packages': True,
-                          'resources': [],
-                          'optimize': 1,
-                          'argv_emulation': True,
-                          'no_chdir': True,
-                          'iconfile': 'osx_icon.icns',
-                          },
-               },
+      setup_requires=[],
       )
 
 


### PR DESCRIPTION
Switch from Py2exe, Reason; not enough documentation
for the tool when it comes to py2to3 support

Create a spec file from the source using pyinstaller with __main__.py
Renamed the __main__.spec(output) to pyinstaller.spec

On mac options used
	pyinstaller  --onefile --icon=icon.ico  --windowed
for windows
	pyinstaller  --windowed is enough for creating a default spec file

Win32com is not available on unix machines so the import failure reported
will not affect the application(--log-level ERROR removes warnings)

Note: we still use the setup.py option "py2app" to build the debian package