### PR TITLE
Avoid creation of intermediate python scripts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,9 +9,9 @@ if hasattr(sys, 'setdefaultencoding'):
     sys.setdefaultencoding('latin-1')
 
 from builtins import str
-from retriever import VERSION,COPYRIGHT
+from retriever.lib.defaults import VERSION,COPYRIGHT
 from retriever.lib.repository import check_for_updates
-from retriever import SCRIPT_LIST
+from retriever.lib.scripts import SCRIPT_LIST
 
 # Create the .rst file for the available datasets
 datasetfile = open("datasets.rst", "w")

--- a/docs/retriever.lib.rst
+++ b/docs/retriever.lib.rst
@@ -68,6 +68,14 @@ retriever.lib.repository module
     :undoc-members:
     :show-inheritance:
 
+retriever.lib.scripts module
+----------------------------
+
+.. automodule:: retriever.lib.scripts
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 retriever.lib.table module
 --------------------------
 

--- a/retriever/__init__.py
+++ b/retriever/__init__.py
@@ -12,28 +12,16 @@ import io
 import os
 import sys
 import csv
-from os.path import join, isfile, getmtime, exists
-from pkg_resources import parse_version
-import imp
 import platform
 
-from retriever.lib.compile import compile_json
-from retriever._version import __version__
+from retriever.lib.defaults import HOME_DIR, ENCODING
 
 current_platform = platform.system().lower()
 if current_platform != 'windows':
     import pwd
 
-VERSION = __version__
-COPYRIGHT = "Copyright (C) 2011-2016 Weecology University of Florida"
-REPO_URL = "https://raw.github.com/weecology/retriever/"
-MASTER_BRANCH = REPO_URL + "master/"
-REPOSITORY = MASTER_BRANCH
-ENCODING = 'ISO-8859-1'
-
 # create the necessary directory structure for storing scripts/raw_data
 # in the ~/.retriever directory
-HOME_DIR = os.path.expanduser('~/.retriever/')
 for dir in (HOME_DIR, os.path.join(HOME_DIR, 'raw_data'), os.path.join(HOME_DIR, 'scripts')):
     if not os.path.exists(dir):
         try:
@@ -46,22 +34,6 @@ for dir in (HOME_DIR, os.path.join(HOME_DIR, 'raw_data'), os.path.join(HOME_DIR,
         except OSError:
             print("The Retriever lacks permission to access the ~/.retriever/ directory.")
             raise
-SCRIPT_SEARCH_PATHS = [
-    "./",
-    'scripts',
-    os.path.join(HOME_DIR, 'scripts/')
-]
-SCRIPT_WRITE_PATH = SCRIPT_SEARCH_PATHS[-1]
-DATA_SEARCH_PATHS = [
-    "./",
-    "{dataset}",
-    "raw_data/{dataset}",
-    os.path.join(HOME_DIR, 'raw_data/{dataset}'),
-]
-DATA_WRITE_PATH = DATA_SEARCH_PATHS[-1]
-
-# Create default data directory
-DATA_DIR = '.'
 
 
 def open_fr(file_name, encoding=ENCODING, encode=True):
@@ -118,57 +90,6 @@ def to_str(object, object_encoding=sys.stdout):
         return str(object).encode(enc, errors='backslashreplace').decode("latin-1")
     else:
         return object
-
-
-def MODULE_LIST(force_compile=False):
-    """Load scripts from scripts directory and return list of modules."""
-    modules = []
-    loaded_scripts = []
-
-    for search_path in [search_path for search_path in SCRIPT_SEARCH_PATHS if exists(search_path)]:
-        to_compile = [
-            file for file in os.listdir(search_path) if file[-5:] == ".json" and
-            file[0] != "_" and (
-                (not isfile(join(search_path, file[:-5] + '.py'))) or (
-                    isfile(join(search_path, file[:-5] + '.py')) and (
-                        getmtime(join(search_path, file[:-5] + '.py')) < getmtime(
-                            join(search_path, file)))) or force_compile)]
-        for script in to_compile:
-            script_name = '.'.join(script.split('.')[:-1])
-            compile_json(join(search_path, script_name))
-
-        files = [file for file in os.listdir(search_path)
-                 if file[-3:] == ".py" and file[0] != "_" and
-                 '#retriever' in ' '.join(open(join(search_path, file), 'r').readlines()[:2]).lower()]
-
-        for script in files:
-            script_name = '.'.join(script.split('.')[:-1])
-            if script_name not in loaded_scripts:
-                loaded_scripts.append(script_name)
-                file, pathname, desc = imp.find_module(script_name, [search_path])
-                try:
-                    new_module = imp.load_module(script_name, file, pathname, desc)
-                    if hasattr(new_module.SCRIPT, "retriever_minimum_version"):
-                        # a script with retriever_minimum_version should be loaded
-                        # only if its compliant with the version of the retriever
-                        if not parse_version(VERSION) >=  parse_version("{}".format(
-                                new_module.SCRIPT.retriever_minimum_version)):
-                            print("{} is supported by Retriever version {}".format(script_name,
-                                                                                   new_module.SCRIPT.retriever_minimum_version))
-                            print("Current version is {}".format(VERSION))
-                            continue
-                    # if the script wasn't found in an early search path
-                    # make sure it works and then add it
-                    new_module.SCRIPT.download
-                    modules.append(new_module)
-                except Exception as e:
-                    sys.stderr.write("Failed to load script: %s (%s)\nException: %s \n" % (
-                        script_name, search_path, str(e)))
-    return modules
-
-
-def SCRIPT_LIST(force_compile=False):
-    return [module.SCRIPT for module in MODULE_LIST(force_compile)]
 
 
 def ENGINE_LIST():

--- a/retriever/__main__.py
+++ b/retriever/__main__.py
@@ -22,7 +22,9 @@ reload(sys)
 if hasattr(sys, 'setdefaultencoding'):
     sys.setdefaultencoding(encoding)
 
-from retriever import VERSION, SCRIPT_LIST, HOME_DIR, sample_script, CITATION
+from retriever import sample_script, CITATION
+from retriever.lib.defaults import VERSION, HOME_DIR
+from retriever.lib.scripts import SCRIPT_LIST
 from retriever.engines import engine_list
 from retriever.lib.repository import check_for_updates
 from retriever.lib.tools import choose_engine, name_matches, reset_retriever

--- a/retriever/compile.py
+++ b/retriever/compile.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
-from retriever import MODULE_LIST
+from retriever.lib.scripts import MODULE_LIST
 
 
 def compile():

--- a/retriever/engines/csvengine.py
+++ b/retriever/engines/csvengine.py
@@ -7,7 +7,8 @@ import sys
 import csv
 
 from retriever.lib.models import Engine
-from retriever import DATA_DIR, open_fw, open_csvw
+from retriever import open_fw, open_csvw
+from retriever.lib.defaults import DATA_DIR
 from retriever.lib.tools import sort_csv
 
 

--- a/retriever/engines/download_only.py
+++ b/retriever/engines/download_only.py
@@ -7,7 +7,7 @@ import inspect
 
 from retriever.lib.engine import filename_from_url
 from retriever.lib.models import Engine, no_cleanup
-from retriever import DATA_DIR, HOME_DIR
+from retriever.lib.defaults import DATA_DIR, HOME_DIR
 
 
 class DummyConnection(object):

--- a/retriever/engines/jsonengine.py
+++ b/retriever/engines/jsonengine.py
@@ -7,7 +7,8 @@ import os
 import json
 
 from retriever.lib.models import Engine
-from retriever import DATA_DIR, open_fw, open_fr
+from retriever import open_fw, open_fr
+from retriever.lib.defaults import DATA_DIR
 from collections import OrderedDict
 from retriever.lib.tools import json2csv, sort_csv
 

--- a/retriever/engines/msaccess.py
+++ b/retriever/engines/msaccess.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 from builtins import str
 import os
 from retriever.lib.models import Engine, no_cleanup
-from retriever import DATA_DIR, current_platform
+from retriever import current_platform
+from retriever.lib.defaults import DATA_DIR
 
 
 class engine(Engine):

--- a/retriever/engines/sqlite.py
+++ b/retriever/engines/sqlite.py
@@ -1,7 +1,7 @@
 from builtins import range
 import os
 from retriever.lib.models import Engine, no_cleanup
-from retriever import DATA_DIR
+from retriever.lib.defaults import DATA_DIR
 
 
 class engine(Engine):

--- a/retriever/engines/xmlengine.py
+++ b/retriever/engines/xmlengine.py
@@ -4,7 +4,8 @@ from builtins import str
 from builtins import object
 from builtins import range
 from retriever.lib.models import Engine
-from retriever import DATA_DIR, open_fr, open_fw
+from retriever import open_fr, open_fw
+from retriever.lib.defaults import DATA_DIR
 from retriever.lib.tools import xml2csv, sort_csv
 
 

--- a/retriever/lib/cleanup.py
+++ b/retriever/lib/cleanup.py
@@ -34,3 +34,7 @@ class Cleanup(object):
     def __init__(self, function=no_cleanup, **kwargs):
         self.function = function
         self.args = kwargs
+
+    def __eq__(self, other):
+        if isinstance(other, Cleanup):
+            return self.args == other.args

--- a/retriever/lib/compile.py
+++ b/retriever/lib/compile.py
@@ -3,7 +3,6 @@ import json
 import sys
 if sys.version_info[0] < 3:
     from codecs import open
-
 from retriever.lib.templates import TEMPLATES
 from retriever.lib.models import Cleanup, Table, correct_invalid_value
 
@@ -12,14 +11,13 @@ def add_dialect(table_dict, table):
     """
     Reads dialect key of JSON script and extracts key-value pairs to store them
     in python script
-
     Contains properties such 'nulls', delimiter', etc
     """
     for (key, val) in table['dialect'].items():
         # dialect related key-value pairs
         # copied as is
         if key == "missingValues":
-            table_dict['cleanup'] = Cleanup(correct_invalid_value, nulls=str(val))
+            table_dict['cleanup'] = Cleanup(correct_invalid_value, nulls=val)
 
         elif key == "delimiter":
             table_dict[key] = str(val)

--- a/retriever/lib/datapackage.py
+++ b/retriever/lib/datapackage.py
@@ -3,7 +3,8 @@ from builtins import input
 import os
 import json
 from time import sleep
-from retriever import SCRIPT_LIST, HOME_DIR, ENCODING
+from retriever.lib.scripts import SCRIPT_LIST
+from retriever.lib.defaults import HOME_DIR, ENCODING
 
 short_names = [script.shortname.lower() for script in SCRIPT_LIST()]
 

--- a/retriever/lib/defaults.py
+++ b/retriever/lib/defaults.py
@@ -1,0 +1,27 @@
+import os
+from retriever._version import __version__
+
+VERSION = __version__
+COPYRIGHT = "Copyright (C) 2011-2016 Weecology University of Florida"
+REPO_URL = "https://raw.github.com/weecology/retriever/"
+MASTER_BRANCH = REPO_URL + "master/"
+REPOSITORY = MASTER_BRANCH
+ENCODING = 'ISO-8859-1'
+
+HOME_DIR = os.path.expanduser('~/.retriever/')
+SCRIPT_SEARCH_PATHS = [
+    "./",
+    'scripts',
+    os.path.join(HOME_DIR, 'scripts/')
+]
+SCRIPT_WRITE_PATH = SCRIPT_SEARCH_PATHS[-1]
+DATA_SEARCH_PATHS = [
+    "./",
+    "{dataset}",
+    "raw_data/{dataset}",
+    os.path.join(HOME_DIR, 'raw_data/{dataset}'),
+]
+DATA_WRITE_PATH = DATA_SEARCH_PATHS[-1]
+
+# Create default data directory
+DATA_DIR = '.'

--- a/retriever/lib/engine.py
+++ b/retriever/lib/engine.py
@@ -19,7 +19,8 @@ import re
 import io
 import time
 from urllib.request import urlretrieve
-from retriever import DATA_SEARCH_PATHS, DATA_WRITE_PATH, open_fr, open_fw, open_csvw
+from retriever import open_fr, open_fw, open_csvw
+from retriever.lib.defaults import DATA_SEARCH_PATHS, DATA_WRITE_PATH
 from retriever.lib.cleanup import no_cleanup
 from retriever.lib.warning import Warning
 

--- a/retriever/lib/get_opts.py
+++ b/retriever/lib/get_opts.py
@@ -9,14 +9,14 @@ from argcomplete.completers import ChoicesCompleter
 
 
 module_list = MODULE_LIST()
-script_list = [module.SCRIPT.shortname for module in module_list]
-json_list = [module.SCRIPT.shortname for module in module_list
+script_list = [module.shortname for module in module_list]
+json_list = [module.shortname for module in module_list
              if os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.json')]
 
 keywords_list = set()
 for module in module_list:
-    if hasattr(module.SCRIPT, "tags"):
-        keywords_list = keywords_list | set(module.SCRIPT.tags)
+    if hasattr(module, "tags"):
+        keywords_list = keywords_list | set(module.tags)
 
 parser = argparse.ArgumentParser(prog="retriever")
 parser.add_argument('-v', '--version', action='version', version=VERSION)

--- a/retriever/lib/get_opts.py
+++ b/retriever/lib/get_opts.py
@@ -1,12 +1,12 @@
 import argparse
 import os
-from retriever import VERSION
+from retriever.lib.defaults import VERSION
+from retriever.lib.scripts import MODULE_LIST
 from retriever.engines import engine_list
 import argcomplete
 
 from argcomplete.completers import ChoicesCompleter
 
-from retriever import MODULE_LIST
 
 module_list = MODULE_LIST()
 script_list = [module.SCRIPT.shortname for module in module_list]

--- a/retriever/lib/get_opts.py
+++ b/retriever/lib/get_opts.py
@@ -11,7 +11,7 @@ from argcomplete.completers import ChoicesCompleter
 module_list = MODULE_LIST()
 script_list = [module.shortname for module in module_list]
 json_list = [module.shortname for module in module_list
-             if os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.json')]
+             if os.path.isfile('.'.join(module._file.split('.')[:-1]) + '.json')]
 
 keywords_list = set()
 for module in module_list:

--- a/retriever/lib/repository.py
+++ b/retriever/lib/repository.py
@@ -9,7 +9,7 @@ import urllib.parse
 import urllib.error
 import imp
 from pkg_resources import parse_version
-from retriever import REPOSITORY, SCRIPT_WRITE_PATH, HOME_DIR
+from retriever.lib.defaults import REPOSITORY, SCRIPT_WRITE_PATH, HOME_DIR
 from retriever.lib.models import file_exists
 
 global abort, executable_name

--- a/retriever/lib/repository.py
+++ b/retriever/lib/repository.py
@@ -66,7 +66,7 @@ def check_for_updates():
             try:
                 file_object, pathname, desc = imp.find_module(''.join(script_name.split('.')[:-1]), [SCRIPT_WRITE_PATH])
                 new_module = imp.load_module(script_name, file_object, pathname, desc)
-                m = str(new_module.SCRIPT.version)
+                m = str(new_module.version)
                 need_to_download = parse_version(str(script_version)) > parse_version(m)
             except:
                 pass

--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -34,7 +34,7 @@ def MODULE_LIST(force_compile=False):
                 file, pathname, desc = imp.find_module(script_name, [search_path])
                 try:
                     new_module = imp.load_module(script_name, file, pathname, desc)
-                    if hasattr(new_module, "retriever_minimum_version"):
+                    if hasattr(new_module.SCRIPT, "retriever_minimum_version"):
                         # a script with retriever_minimum_version should be loaded
                         # only if its compliant with the version of the retriever
                         if not parse_version(VERSION) >=  parse_version("{}".format(

--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -1,0 +1,60 @@
+
+import os
+from os.path import join, isfile, getmtime, exists
+from pkg_resources import parse_version
+import imp
+import sys
+
+from retriever.lib.defaults import SCRIPT_SEARCH_PATHS, VERSION
+
+from retriever.lib.compile import compile_json
+
+def MODULE_LIST(force_compile=False):
+    """Load scripts from scripts directory and return list of modules."""
+    modules = []
+    loaded_scripts = []
+
+    for search_path in [search_path for search_path in SCRIPT_SEARCH_PATHS if exists(search_path)]:
+        to_compile = [
+            file for file in os.listdir(search_path) if file[-5:] == ".json" and
+            file[0] != "_" and (
+                (not isfile(join(search_path, file[:-5] + '.py'))) or (
+                    isfile(join(search_path, file[:-5] + '.py')) and (
+                        getmtime(join(search_path, file[:-5] + '.py')) < getmtime(
+                            join(search_path, file)))) or force_compile)]
+        for script in to_compile:
+            script_name = '.'.join(script.split('.')[:-1])
+            compile_json(join(search_path, script_name))
+
+        files = [file for file in os.listdir(search_path)
+                 if file[-3:] == ".py" and file[0] != "_" and
+                 '#retriever' in ' '.join(open(join(search_path, file), 'r').readlines()[:2]).lower()]
+
+        for script in files:
+            script_name = '.'.join(script.split('.')[:-1])
+            if script_name not in loaded_scripts:
+                loaded_scripts.append(script_name)
+                file, pathname, desc = imp.find_module(script_name, [search_path])
+                try:
+                    new_module = imp.load_module(script_name, file, pathname, desc)
+                    if hasattr(new_module.SCRIPT, "retriever_minimum_version"):
+                        # a script with retriever_minimum_version should be loaded
+                        # only if its compliant with the version of the retriever
+                        if not parse_version(VERSION) >=  parse_version("{}".format(
+                                new_module.SCRIPT.retriever_minimum_version)):
+                            print("{} is supported by Retriever version {}".format(script_name,
+                                                                                   new_module.SCRIPT.retriever_minimum_version))
+                            print("Current version is {}".format(VERSION))
+                            continue
+                    # if the script wasn't found in an early search path
+                    # make sure it works and then add it
+                    new_module.SCRIPT.download
+                    modules.append(new_module)
+                except Exception as e:
+                    sys.stderr.write("Failed to load script: %s (%s)\nException: %s \n" % (
+                        script_name, search_path, str(e)))
+    return modules
+
+
+def SCRIPT_LIST(force_compile=False):
+    return [module.SCRIPT for module in MODULE_LIST(force_compile)]

--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -20,6 +20,8 @@ def MODULE_LIST(force_compile=False):
             script_name = '.'.join(script.split('.')[:-1])
             if script_name not in loaded_scripts:
                 compiled_script = compile_json(join(search_path, script_name))
+                setattr(compiled_script, "_file", os.path.join(search_path, script))
+                setattr(compiled_script, "_name", script_name)
                 modules.append(compiled_script)
                 loaded_scripts.append(script_name)
 
@@ -46,6 +48,8 @@ def MODULE_LIST(force_compile=False):
                     # if the script wasn't found in an early search path
                     # make sure it works and then add it
                     new_module.SCRIPT.download
+                    setattr(new_module.SCRIPT, "_file", os.path.join(search_path, script))
+                    setattr(new_module.SCRIPT, "_name", script_name)
                     modules.append(new_module.SCRIPT)
                 except Exception as e:
                     sys.stderr.write("Failed to load script: %s (%s)\nException: %s \n" % (

--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -6,8 +6,8 @@ import imp
 import sys
 
 from retriever.lib.defaults import SCRIPT_SEARCH_PATHS, VERSION
-
 from retriever.lib.compile import compile_json
+
 
 def MODULE_LIST(force_compile=False):
     """Load scripts from scripts directory and return list of modules."""
@@ -15,16 +15,13 @@ def MODULE_LIST(force_compile=False):
     loaded_scripts = []
 
     for search_path in [search_path for search_path in SCRIPT_SEARCH_PATHS if exists(search_path)]:
-        to_compile = [
-            file for file in os.listdir(search_path) if file[-5:] == ".json" and
-            file[0] != "_" and (
-                (not isfile(join(search_path, file[:-5] + '.py'))) or (
-                    isfile(join(search_path, file[:-5] + '.py')) and (
-                        getmtime(join(search_path, file[:-5] + '.py')) < getmtime(
-                            join(search_path, file)))) or force_compile)]
+        to_compile = [file for file in os.listdir(search_path) if file[-5:] == ".json" and file[0] != "_"]
         for script in to_compile:
             script_name = '.'.join(script.split('.')[:-1])
-            compile_json(join(search_path, script_name))
+            if script_name not in loaded_scripts:
+                compiled_script = compile_json(join(search_path, script_name))
+                modules.append(compiled_script)
+                loaded_scripts.append(script_name)
 
         files = [file for file in os.listdir(search_path)
                  if file[-3:] == ".py" and file[0] != "_" and
@@ -37,7 +34,7 @@ def MODULE_LIST(force_compile=False):
                 file, pathname, desc = imp.find_module(script_name, [search_path])
                 try:
                     new_module = imp.load_module(script_name, file, pathname, desc)
-                    if hasattr(new_module.SCRIPT, "retriever_minimum_version"):
+                    if hasattr(new_module, "retriever_minimum_version"):
                         # a script with retriever_minimum_version should be loaded
                         # only if its compliant with the version of the retriever
                         if not parse_version(VERSION) >=  parse_version("{}".format(
@@ -49,7 +46,7 @@ def MODULE_LIST(force_compile=False):
                     # if the script wasn't found in an early search path
                     # make sure it works and then add it
                     new_module.SCRIPT.download
-                    modules.append(new_module)
+                    modules.append(new_module.SCRIPT)
                 except Exception as e:
                     sys.stderr.write("Failed to load script: %s (%s)\nException: %s \n" % (
                         script_name, search_path, str(e)))
@@ -57,4 +54,4 @@ def MODULE_LIST(force_compile=False):
 
 
 def SCRIPT_LIST(force_compile=False):
-    return [module.SCRIPT for module in MODULE_LIST(force_compile)]
+    return MODULE_LIST(force_compile)

--- a/retriever/lib/templates.py
+++ b/retriever/lib/templates.py
@@ -138,7 +138,7 @@ class HtmlTableTemplate(Script):
     pass
 
 
-TEMPLATES = [
-    ("Basic Text", BasicTextTemplate),
-    ("HTML Table", HtmlTableTemplate),
-]
+TEMPLATES = {
+   "default": BasicTextTemplate,
+   "html_table": HtmlTableTemplate
+}

--- a/retriever/lib/templates.py
+++ b/retriever/lib/templates.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from builtins import object
 import os
 import shutil
-from retriever import DATA_DIR
+from retriever.lib.defaults import DATA_DIR
 from retriever.lib.models import *
 from retriever.lib.tools import choose_engine
 

--- a/retriever/lib/tools.py
+++ b/retriever/lib/tools.py
@@ -21,7 +21,8 @@ import shutil
 from decimal import Decimal
 from hashlib import md5
 
-from retriever import HOME_DIR, open_fr, open_fw, open_csvw
+from retriever import open_fr, open_fw, open_csvw
+from retriever.lib.defaults import HOME_DIR
 from retriever.lib.models import *
 import csv
 import json

--- a/retriever/try_install_all.py
+++ b/retriever/try_install_all.py
@@ -90,14 +90,14 @@ for module in MODULE_LIST:
     for (key, value) in list(TEST_ENGINES.items()):
         if module.shortname.lower() not in IGNORE:
             if value != None:
-                print("==>", module.__name__, value.name, "..........", module.shortname)
+                print("==>", module._name, value.name, "..........", module.shortname)
                 try:
                     module.download(value)
                 except KeyboardInterrupt:
                     pass
                 except Exception as e:
                     print("ERROR.")
-                    errors.append((key, module.__name__, e))
+                    errors.append((key, module._name, e))
             else:
                 errors.append((key, "No connection detected......" + module.shortname))
 print('')

--- a/retriever/try_install_all.py
+++ b/retriever/try_install_all.py
@@ -88,18 +88,18 @@ for engine in ENGINE_LIST:
 errors = []
 for module in MODULE_LIST:
     for (key, value) in list(TEST_ENGINES.items()):
-        if module.SCRIPT.shortname.lower() not in IGNORE:
+        if module.shortname.lower() not in IGNORE:
             if value != None:
-                print("==>", module.__name__, value.name, "..........", module.SCRIPT.shortname)
+                print("==>", module.__name__, value.name, "..........", module.shortname)
                 try:
-                    module.SCRIPT.download(value)
+                    module.download(value)
                 except KeyboardInterrupt:
                     pass
                 except Exception as e:
                     print("ERROR.")
                     errors.append((key, module.__name__, e))
             else:
-                errors.append((key, "No connection detected......" + module.SCRIPT.shortname))
+                errors.append((key, "No connection detected......" + module.shortname))
 print('')
 if errors:
     print("Engine, Dataset, Error")

--- a/retriever/try_install_all.py
+++ b/retriever/try_install_all.py
@@ -13,7 +13,8 @@ import os
 import sys
 from imp import reload
 from retriever.lib.tools import choose_engine
-from retriever import MODULE_LIST, ENGINE_LIST, SCRIPT_LIST
+from retriever.lib.scripts import MODULE_LIST, SCRIPT_LIST
+from retriever import ENGINE_LIST
 
 reload(sys)
 if hasattr(sys, 'setdefaultencoding'):

--- a/scripts/MammalSuperTree.py
+++ b/scripts/MammalSuperTree.py
@@ -1,5 +1,5 @@
 #retriever
-from retriever import VERSION
+from retriever.lib.defaults import VERSION
 from retriever.lib.templates import DownloadOnlyTemplate
 
 SCRIPT = DownloadOnlyTemplate(name="Mammal Super Tree",

--- a/scripts/breed_bird_survey.py
+++ b/scripts/breed_bird_survey.py
@@ -14,8 +14,8 @@ import zipfile
 from decimal import Decimal
 from retriever.lib.templates import Script
 from retriever.lib.models import Table, Cleanup, no_cleanup, correct_invalid_value
-from retriever import HOME_DIR, open_fr, open_fw
-
+from retriever import open_fr, open_fw
+from retriever.lib.defaults import HOME_DIR
 
 class main(Script):
     def __init__(self, **kwargs):

--- a/scripts/breed_bird_survey_50stop.py
+++ b/scripts/breed_bird_survey_50stop.py
@@ -15,7 +15,8 @@ import zipfile
 from decimal import Decimal
 from retriever.lib.templates import Script
 from retriever.lib.models import Table, Cleanup, no_cleanup, correct_invalid_value
-from retriever import HOME_DIR, open_fr, open_fw
+from retriever import open_fr, open_fw
+from retriever.lib.defaults import HOME_DIR
 
 
 class main(Script):

--- a/scripts/plant_life_hist_eu.py
+++ b/scripts/plant_life_hist_eu.py
@@ -3,7 +3,8 @@
 from builtins import str
 from retriever.lib.models import Table, Cleanup, correct_invalid_value
 from retriever.lib.templates import Script
-from retriever import HOME_DIR, open_fr, open_fw
+from retriever import open_fr, open_fw
+from retriever.lib.defaults import HOME_DIR
 
 
 class main(Script):

--- a/scripts/wood_density.py
+++ b/scripts/wood_density.py
@@ -12,7 +12,8 @@ from imp import reload
 from retriever.lib.templates import Script
 from retriever.lib.models import Table
 from retriever.lib.excel import Excel
-from retriever import HOME_DIR, open_fr, open_fw, open_csvw, to_str
+from retriever import open_fr, open_fw, open_csvw, to_str
+from retriever.lib.defaults import HOME_DIR
 
 class main(Script):
     def __init__(self, **kwargs):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -394,9 +394,9 @@ def get_output_as_csv(dataset, engines, tmpdir, db):
     workdir = tmpdir.mkdtemp()
     workdir.chdir()
     script_module = get_script_module(dataset["name"])
-    script_module.SCRIPT.download(engines)
-    script_module.SCRIPT.engine.final_cleanup()
-    script_module.SCRIPT.engine.to_csv()
+    script_module.download(engines)
+    script_module.engine.final_cleanup()
+    script_module.engine.to_csv()
     # get filename and append .csv
     csv_file = engines.opts['table_name'].format(db=db, table=dataset["name"])
     # csv engine already has the .csv extension

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -15,7 +15,8 @@ if hasattr(sys, 'setdefaultencoding'):
     sys.setdefaultencoding(encoding)
 import pytest
 from retriever.lib.compile import compile_json
-from retriever import HOME_DIR, ENGINE_LIST
+from retriever.lib.defaults import HOME_DIR
+from retriever import ENGINE_LIST
 from retriever.lib.tools import file_2string
 from retriever.lib.tools import create_file
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -372,7 +372,6 @@ def setup_module():
             os.makedirs(os.path.join(HOME_DIR, "raw_data", test['name']))
         create_file(test['raw_data'], os.path.join(HOME_DIR, "raw_data", test['name'], test['name'] + '.txt'))
         create_file(test['script'], os.path.join(HOME_DIR, "scripts", test['name'] + '.json'))
-        compile_json(os.path.join(HOME_DIR, "scripts", test['name']))
 
 
 def teardown_module():
@@ -380,7 +379,6 @@ def teardown_module():
     for test in tests:
         shutil.rmtree(os.path.join(HOME_DIR, "raw_data", test['name']))
         os.remove(os.path.join(HOME_DIR, "scripts", test['name'] + '.json'))
-        os.remove(os.path.join(HOME_DIR, "scripts", test['name'] + '.py'))
         os.system("rm -r *{}".format(test['name']))
         os.system("rm testdb.sqlite")
 
@@ -409,9 +407,7 @@ def get_output_as_csv(dataset, engines, tmpdir, db):
 
 def get_script_module(script_name):
     """Load a script module"""
-    file, pathname, desc = imp.find_module(script_name, [os.path.join(HOME_DIR, "scripts")])
-    return imp.load_module(script_name, file, pathname, desc)
-
+    return compile_json(os.path.join(HOME_DIR, "scripts", script_name))
 
 mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, csv_engine, download_engine, json_engine, xml_engine = ENGINE_LIST()
 

--- a/test/test_regression_cli.py
+++ b/test/test_regression_cli.py
@@ -14,6 +14,8 @@ if hasattr(sys, 'setdefaultencoding'):
 import pytest
 from retriever.lib.tools import getmd5
 from retriever import ENGINE_LIST
+from retriever.lib.defaults import HOME_DIR
+from retriever.lib.compile import compile_json
 
 # Set postgres password, Appveyor service needs the password given
 # The Travis service obtains the password from the config file.
@@ -43,8 +45,7 @@ db_md5 = [
 
 def get_script_module(script_name):
     """Load a script module from the downloaded scripts directory in the retriever"""
-    file, pathname, desc = imp.find_module(script_name, [working_script_dir])
-    return imp.load_module(script_name, file, pathname, desc)
+    return compile_json(os.path.join(working_script_dir, script_name))
 
 
 def get_csv_md5(dataset, engines, tmpdir):

--- a/test/test_regression_cli.py
+++ b/test/test_regression_cli.py
@@ -51,9 +51,9 @@ def get_csv_md5(dataset, engines, tmpdir):
     workdir = tmpdir.mkdtemp()
     workdir.chdir()
     script_module = get_script_module(dataset)
-    script_module.SCRIPT.download(engines)
-    script_module.SCRIPT.engine.final_cleanup()
-    script_module.SCRIPT.engine.to_csv()
+    script_module.download(engines)
+    script_module.engine.final_cleanup()
+    script_module.engine.to_csv()
     current_md5 = getmd5(data=str(workdir), data_type='dir')
     return current_md5
 

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -27,6 +27,7 @@ from retriever.lib.tools import create_file
 from retriever.lib.tools import file_2string
 from retriever.lib.datapackage import clean_input, is_empty
 from retriever.lib.compile import add_dialect, add_schema
+from retriever.lib.cleanup import Cleanup
 
 # Create simple engine fixture
 test_engine = Engine()
@@ -377,8 +378,8 @@ def test_add_dialect():
     table['dialect']['dummy_key'] = 'dummy_value'
 
     result = {}
-    result['cleanup'] = 'Cleanup(correct_invalid_value, nulls=\x00)'
-    result['delimiter'] = "'\t'"
+    result['cleanup'] = Cleanup(correct_invalid_value, nulls='\x00')
+    result['delimiter'] = '\t'
     result['dummy_key'] = 'dummy_value'
 
     add_dialect(table_dict, table)

--- a/version.py
+++ b/version.py
@@ -10,14 +10,14 @@ def get_module_version():
     modules = MODULE_LIST()
     scripts = []
     for module in modules:
-        if module.SCRIPT.public:
-            if os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.json') and module.SCRIPT.version:
+        if module.public:
+            if os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.json') and module.version:
                 module_name = module.__name__ + '.json'
-                scripts.append(','.join([module_name, str(module.SCRIPT.version)]))
+                scripts.append(','.join([module_name, str(module.version)]))
             elif os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.py') and \
                     not os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.json'):
                 module_name = module.__name__ + '.py'
-                scripts.append(','.join([module_name, str(module.SCRIPT.version)]))
+                scripts.append(','.join([module_name, str(module.version)]))
 
     scripts = sorted(scripts, key = str.lower)
     return scripts

--- a/version.py
+++ b/version.py
@@ -11,12 +11,12 @@ def get_module_version():
     scripts = []
     for module in modules:
         if module.public:
-            if os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.json') and module.version:
-                module_name = module.__name__ + '.json'
+            if os.path.isfile('.'.join(module._file.split('.')[:-1]) + '.json') and module.version:
+                module_name = module._name + '.json'
                 scripts.append(','.join([module_name, str(module.version)]))
-            elif os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.py') and \
-                    not os.path.isfile('.'.join(module.__file__.split('.')[:-1]) + '.json'):
-                module_name = module.__name__ + '.py'
+            elif os.path.isfile('.'.join(module._file.split('.')[:-1]) + '.py') and \
+                    not os.path.isfile('.'.join(module._file.split('.')[:-1]) + '.json'):
+                module_name = module._name + '.py'
                 scripts.append(','.join([module_name, str(module.version)]))
 
     scripts = sorted(scripts, key = str.lower)

--- a/version.py
+++ b/version.py
@@ -1,7 +1,8 @@
 """Generates a configuration file containing the version number."""
 from __future__ import absolute_import
 import os
-from retriever import VERSION, MODULE_LIST
+from retriever.lib.defaults import VERSION
+from retriever.lib.scripts import MODULE_LIST
 
 
 def get_module_version():


### PR DESCRIPTION
Hi @henrykironde, @ethanwhite. This PR avoids creation of separate python scripts from pre-existing .json files and directly creates `Script` template instances. I have also edited the tests a bit to reflect the changes. The functionality can be verified on any .json file without a compiled .py script. 

Please review the code. Looking forward to your suggestions. If accepted, we can also get rid of the compiled python template files in `scripts/` directory. We can merge the functions `MODULE_LIST` and `SCRIPT_LIST` as well since their functionalities are identical. 