### PR TITLE
Added citation for USDA plants

### DIFF
--- a/scripts/plant_taxonomy_us.json
+++ b/scripts/plant_taxonomy_us.json
@@ -54,5 +54,5 @@
     "urls": {
         "PlantTaxonomy": "http://plants.usda.gov/java/downloadData?fileName=plantlst.txt&static=true"
     },
-    "version": "1.1.1"
+    "version": "1.1.2"
 }

--- a/scripts/plant_taxonomy_us.json
+++ b/scripts/plant_taxonomy_us.json
@@ -1,4 +1,5 @@
 {
+    "citation": "USDA, NRCS. 2017. The PLANTS Database (http://plants.usda.gov, DATEOFDOWNLOAD). National Plant Data Team, Greensboro, NC 27401-4901 USA.",
     "description": "Plant taxonomy data for the United States from the USDA plants website",
     "homepage": "http://plants.usda.gov",
     "keywords": [


### PR DESCRIPTION
noticed missing citation on https://retriever.readthedocs.io/en/latest/datasets.html
I gather this is where to add the citation? Not sure if I got the correct format.

The citation information is from https://plants.usda.gov/java/citePlants