### PR TITLE
Option to clear local cache

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -27,7 +27,6 @@ from retriever.lib.tools import choose_engine, name_matches, reset_retriever
 from retriever.lib.get_opts import parser
 from retriever.lib.datapackage import create_json, edit_json
 
-
 def main():
     """This function launches the Data Retriever."""
     if len(sys.argv) == 1:
@@ -173,6 +172,11 @@ def main():
             debug = False
             sys.tracebacklimit = 0
 
+        if hasattr(args, 'debug') and args.not_cached:
+            use_cache = False
+        else:
+            use_cache = True
+
         if args.dataset is not None:
             scripts = name_matches(script_list, args.dataset)
         else:
@@ -181,7 +185,7 @@ def main():
             for dataset in scripts:
                 print("=> Installing", dataset.name)
                 try:
-                    dataset.download(engine, debug=debug)
+                    dataset.download(engine, debug=debug, use_cache=use_cache)
                     dataset.engine.final_cleanup()
                 except KeyboardInterrupt:
                     pass

--- a/engines/download_only.py
+++ b/engines/download_only.py
@@ -97,13 +97,13 @@ class engine(Engine):
             # If the file doesn't exist, download it
             self.download_file(url, filename)
 
-    def insert_data_from_url(self, url):
+    def insert_data_from_url(self, url, use_cache=True):
         """Insert data from a web resource"""
         filename = filename_from_url(url)
         find = self.find_file(filename)
         if not find:
             self.create_raw_data_dir()
-            self.download_file(url, filename)
+            self.download_file(url, filename, use_cache)
 
     def find_file(self, filename):
         """Checks for the given file and adds it to the list of all files"""

--- a/lib/engine.py
+++ b/lib/engine.py
@@ -165,7 +165,7 @@ class Engine(object):
 
         if self.table.header_rows > 0 and not self.table.columns:
             source = (skip_rows,
-                           (self.table.header_rows-1, self.load_data(file_path)))
+                      (self.table.header_rows - 1, self.load_data(file_path)))
 
             lines = gen_from_source(source)
             header = next(lines)
@@ -173,7 +173,6 @@ class Engine(object):
 
             source = (skip_rows,
                       (self.table.header_rows, self.load_data(file_path)))
-
 
             lines = gen_from_source(source)
 
@@ -386,9 +385,9 @@ class Engine(object):
             db_name = name
         return db_name.replace('-', '_')
 
-    def download_file(self, url, filename):
+    def download_file(self, url, filename, use_cache=True):
         """Downloads a file to the raw data directory."""
-        if not self.find_file(filename):
+        if not self.find_file(filename) or not use_cache:
             path = self.format_filename(filename)
             self.create_raw_data_dir()
             print("\nDownloading " + filename + "...")
@@ -623,18 +622,18 @@ class Engine(object):
                         (self.load_data, (filename, ))))
         self.add_to_table(data_source)
 
-    def insert_data_from_url(self, url):
+    def insert_data_from_url(self, url, use_cache=True):
         """Insert data from a web resource, such as a text file."""
         filename = filename_from_url(url)
         find = self.find_file(filename)
-        if find:
+        if find and use_cache:
             # Use local copy
             self.insert_data_from_file(find)
         else:
             # Save a copy of the file locally, then load from that file
             self.create_raw_data_dir()
             print("\nSaving a copy of " + filename + "...")
-            self.download_file(url, filename)
+            self.download_file(url, filename, use_cache)
             self.insert_data_from_file(self.find_file(filename))
 
     def insert_statement(self, values):

--- a/lib/get_opts.py
+++ b/lib/get_opts.py
@@ -38,6 +38,7 @@ edit_json_parser.add_argument('filename', help='script filename')
 reset_parser.add_argument('scope', help='things to reset: all, scripts, data, or connections', choices=['all', 'scripts', 'data', 'connections'])
 install_parser.add_argument('--compile', help='force re-compile of script before downloading', action='store_true')
 install_parser.add_argument('--debug', help='run in debug mode', action='store_true')
+install_parser.add_argument('--not-cached', help='overwrites local cache of raw data', action='store_true')
 download_parser.add_argument('dataset', help='dataset name')
 ls_parser.add_argument('-l', help='verbose list of datasets containing following keywords (lists all when no keywords are specified)', nargs='*')
 delete_json_parser.add_argument('dataset', help='dataset name')
@@ -68,7 +69,7 @@ for engine in engine_list:
             # [--subdir [SUBDIR]]
 
             # subdir doesn't take any arguments, if included takes True if excluded takes False
-            if arg_name.lower()== "subdir":
+            if arg_name.lower() == "subdir":
                 download_parser.add_argument('--%s' % arg_name, '-%s' % abbreviation, help=help_msg, default=default, action='store_true')
                 # parser.add_argument('--foo', action='store_const', const = False)
             else:

--- a/lib/templates.py
+++ b/lib/templates.py
@@ -38,9 +38,10 @@ class Script(object):
             desc += "\n" + self.reference_url()
         return desc
 
-    def download(self, engine=None, debug=False):
+    def download(self, engine=None, debug=False, use_cache=True):
         self.engine = self.checkengine(engine)
         self.engine.debug = debug
+        self.engine.use_cache = use_cache
         self.engine.db_name = self.shortname
         self.engine.create_db()
 
@@ -89,8 +90,8 @@ class BasicTextTemplate(Script):
     def __init__(self, **kwargs):
         Script.__init__(self, **kwargs)
 
-    def download(self, engine=None, debug=False):
-        Script.download(self, engine, debug)
+    def download(self, engine=None, debug=False, use_cache=True):
+        Script.download(self, engine, debug, use_cache)
 
         for key in list(self.urls.keys()):
             if key not in list(self.tables.keys()):
@@ -99,7 +100,7 @@ class BasicTextTemplate(Script):
 
         for key, value in list(self.urls.items()):
             self.engine.auto_create_table(self.tables[key], url=value)
-            self.engine.insert_data_from_url(value)
+            self.engine.insert_data_from_url(value, use_cache)
             self.tables[key].record_id = 0
         return self.engine
 
@@ -117,13 +118,13 @@ class DownloadOnlyTemplate(Script):
     def __init__(self, **kwargs):
         Script.__init__(self, **kwargs)
 
-    def download(self, engine=None, debug=False):
+    def download(self, engine=None, debug=False, use_cache=True):
         if engine.name != "Download Only":
             raise Exception("This dataset contains only non-tabular data files, and can only be used with the 'download only' engine.\nTry 'retriever download datasetname instead.")
-        Script.download(self, engine, debug)
+        Script.download(self, engine, debug, use_cache)
 
         for filename, url in self.urls.items():
-            self.engine.download_file(url, filename)
+            self.engine.download_file(url, filename, use_cache)
             if os.path.exists(self.engine.format_filename(filename)):
                 shutil.copy(self.engine.format_filename(filename), DATA_DIR)
             else:


### PR DESCRIPTION
fix for #134 
```download_file``` function in  ```./lib/engine.py```  is being called twice. So this particular fix downloads the data file twice when there is no prior data file present and we run ```retriever install --not-cached csv iris```.
For the general case when the data file is already present and we need install by clearing local cache it works correctly.
