### PR TITLE
repair citation on foreset_fires_portugal

### DIFF
--- a/scripts/forest_fires_portugal.json
+++ b/scripts/forest_fires_portugal.json
@@ -1,5 +1,5 @@
 {
-    "citation": "[Cortez and Morais, 2007] P. Cortez and A. Morais. A Data Mining Approach to Predict Forest Fires using Meteorological Data. In J. Neves, M. F. Santos and J. Machado Eds., New Trends in Artificial Intelligence, Proceedings of the 13th EPIA 2007 - Portuguese Conference on Artificial Intelligence, December, Guimar\u00e3es, Portugal, pp. 512-523, 2007. APPIA, ISBN-13 978-989-95618-0-9.",
+    "citation": "P. Cortez and A. Morais. A Data Mining Approach to Predict Forest Fires using Meteorological Data. In J. Neves, M. F. Santos and J. Machado Eds., New Trends in Artificial Intelligence, Proceedings of the 13th EPIA 2007 - Portuguese Conference on Artificial Intelligence, December, Guimarães, Portugal, pp. 512-523, 2007. APPIA, ISBN-13 978-989-95618-0-9.",
     "description": "A database for regression analysis with the aim of predicting burned areas of forestry using meteorological and other data.",
     "homepage": "http://archive.ics.uci.edu/ml/datasets/Forest+Fires",
     "keywords": [],
@@ -71,5 +71,5 @@
     "urls": {
         "data": "http://archive.ics.uci.edu/ml/machine-learning-databases/forest-fires/forestfires.csv"
     },
-    "version": "1.1.1"
+    "version": "1.1.2"
 }

--- a/version.txt
+++ b/version.txt
@@ -14,7 +14,7 @@ community_abundance_misc.json,1.0.1
 elton_traits.json,1.1.1
 fish_parasite_hosts.json,1.1.1
 forest_biomass_china.json,1.1.1
-forest_fires_portugal.json,1.1.1
+forest_fires_portugal.json,1.1.2
 forest_inventory_analysis.py,1.3.1
 forest_plots_michigan.json,1.1.1
 forest_plots_wghats.json,1.1.1


### PR DESCRIPTION
The citation string had some byte representation for one of the non ascii characters.