### PR TITLE
Adding the feature to lookup credentials file in reference to #421

### DIFF
--- a/retriever/__init__.py
+++ b/retriever/__init__.py
@@ -30,6 +30,8 @@ REPO_URL = "https://raw.github.com/weecology/retriever/"
 MASTER_BRANCH = REPO_URL + "master/"
 REPOSITORY = MASTER_BRANCH
 ENCODING = 'ISO-8859-1'
+PGPASS_FILE_PATH = os.path.expanduser('~/.pgpass')
+MYSQL_CONF_PATH = os.path.expanduser('~/.my.cnf')
 
 # create the necessary directory structure for storing scripts/raw_data
 # in the ~/.retriever directory

--- a/retriever/engines/mysql.py
+++ b/retriever/engines/mysql.py
@@ -1,9 +1,9 @@
 from __future__ import print_function
 from builtins import str
 import os
-import io
 from retriever.lib.models import Engine, no_cleanup
-from retriever import ENCODING, MYSQL_CONF_PATH
+from retriever import ENCODING, MYSQL_CONF_PATH, open_fr
+import re
 
 
 class engine(Engine):
@@ -20,25 +20,13 @@ class engine(Engine):
         "bool": "BOOL",
     }
     max_int = 4294967295
-    try:
-        sql_conf = io.open(MYSQL_CONF_PATH, 'r')
-        for line in sql_conf:
-            if re.search("user=", line):
-                username = re.search("\"\"", line).group(1)
-            elif re.search("password=", line):
-                password = re.search("\"\"", line).group(1)
-            else:
-                pass
-    except IOError:
-        username = "root"
-        password = ""
-        
+
     required_opts = [("user",
                       "Enter your MySQL username",
-                      username),
+                      "root"),
                      ("password",
                       "Enter your password",
-                      password),
+                      ""),
                      ("host",
                       "Enter your MySQL host",
                       "localhost"),
@@ -52,6 +40,26 @@ class engine(Engine):
                       "Format of table name",
                       "{db}.{table}"),
                      ]
+
+    def check_credentials(self):
+        """
+        Checks the credentials of the user in the file path ~/.my.cnf for the MySQL
+        credentials by checking the username provided by the user in cli.
+        If found, it updates the credentials to initialize the connection, else uses the
+        default ones.
+        """
+        self.get_input()
+        if os.path.exists(MYSQL_CONF_PATH):
+            sql_conf = open_fr(MYSQL_CONF_PATH)
+            sql_conf_lines = sql_conf.readlines()
+            for line in sql_conf_lines:
+                if re.search("user = ", line) and re.sub("user = ", "", line) == self.opts["user"]:
+                    username = re.sub("user = ", "", line)
+                    pswd_line_index = sql_conf_lines.index(line)+1
+                    while not (re.search("password = ", sql_conf_lines[pswd_line_index])):
+                        pswd_line_index+=1
+                    password = re.sub("password = ", "", sql_conf_lines[pswd_line_index])
+                    self.opts["password"] = password
 
     def create_db_statement(self):
         """Returns a SQL statement to create a database."""
@@ -121,6 +129,7 @@ IGNORE """ + str(self.table.header_rows) + """ LINES
 
     def get_connection(self):
         """Gets the db connection."""
+        self.check_credentials()
         args = {'host': self.opts['host'],
                 'port': int(self.opts['port']),
                 'user': self.opts['user'],
@@ -128,5 +137,4 @@ IGNORE """ + str(self.table.header_rows) + """ LINES
         import pymysql as dbapi
         import pymysql.constants.CLIENT as client
         args['client_flag'] = client.LOCAL_FILES
-        self.get_input()
         return dbapi.connect(**args)

--- a/retriever/engines/mysql.py
+++ b/retriever/engines/mysql.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
 from builtins import str
 import os
+import io
 from retriever.lib.models import Engine, no_cleanup
-from retriever import ENCODING
+from retriever import ENCODING, MYSQL_CONF_PATH
 
 
 class engine(Engine):
@@ -19,12 +20,25 @@ class engine(Engine):
         "bool": "BOOL",
     }
     max_int = 4294967295
+    try:
+        sql_conf = io.open(MYSQL_CONF_PATH, 'r')
+        for line in sql_conf:
+            if re.search("user=", line):
+                username = re.search("\"\"", line).group(1)
+            elif re.search("password=", line):
+                password = re.search("\"\"", line).group(1)
+            else:
+                pass
+    except IOError:
+        username = "root"
+        password = ""
+        
     required_opts = [("user",
                       "Enter your MySQL username",
-                      "root"),
+                      username),
                      ("password",
                       "Enter your password",
-                      ""),
+                      password),
                      ("host",
                       "Enter your MySQL host",
                       "localhost"),

--- a/retriever/engines/postgres.py
+++ b/retriever/engines/postgres.py
@@ -1,8 +1,7 @@
 import os
 import io
 from retriever.lib.models import Engine, no_cleanup
-from retriever import ENCODING, PGPASS_FILE_PATH
-import io
+from retriever import ENCODING, PGPASS_FILE_PATH, open_fr
 
 class engine(Engine):
     """Engine instance for PostgreSQL."""
@@ -18,30 +17,22 @@ class engine(Engine):
         "bool": "boolean",
     }
     max_int = 2147483647
-    try:
-        pgpass_file = io.open(PGPASS_FILE_PATH, 'r')
-        pgpass_credentials = pgpass_file.split(':') # Split the credentials file of the format hostname:port:database:username:password
-        pgpass_lookup = {'username': pgpass_credentials[3], 'password': pgpass_credentials[4], 'host': pgpass_credentials[0], 'port': pgpass_credentials[1], 'database': pgpass_credentials[2]}
-    except IOError:
-        pgpass_lookup = {'username': "postgres", 'password': "", 'host': "localhost", 'port': 5432, 'database': "postgres"}
 
-    for key in pgpass_lookup.keys():
-        if pgpass_lookup[key] == "*" : pgpass_lookup[key] = ""
     required_opts = [("user",
                       "Enter your PostgreSQL username",
-                      pgpass_lookup['username']),
+                      "postgres"),
                      ("password",
                       "Enter your password",
-                      pgpass_lookup['password']),
+                      ""),
                      ("host",
                       "Enter your PostgreSQL host",
-                      pgpass_lookup['host']),
+                      "localhost"),
                      ("port",
                       "Enter your PostgreSQL port",
-                      pgpass_lookup['port']),
+                      5432),
                      ("database",
                       "Enter your PostgreSQL database name",
-                      pgpass_lookup['database']),
+                      "postgres"),
                      ("database_name",
                       "Format of schema name",
                       "{db}"),
@@ -49,6 +40,27 @@ class engine(Engine):
                       "Format of table name",
                       "{db}.{table}"),
                      ]
+
+    def check_credentials(self):
+        """
+        Checks the credentials of the user in the file path ~/.pgpass for the postgreSQL
+        credentials by checking the username provided by the user in cli.
+        If found, it updates the credentials to initialize the connection, else uses the
+        default ones.
+        """
+        self.get_input()
+        if os.path.exists(PGPASS_FILE_PATH):
+            pgpass_file = open_fr(PGPASS_FILE_PATH)
+            # Map the index of PostgreSQL credentials to self.opts dictionary keys
+            pg_map_keys = {"user": 3, "password": 4, "host": 0, "port": 1, "database": 2}
+            # Split the credentials file of the format
+            # hostname:port:database:username:password
+            for line in pgpass_file:
+                pgpass_credentials = line.split(":")
+                if self.opts["user"] == pgpass_credentials[pg_map_keys["user"]]:
+                    for key in self.opts.keys():
+                        if not self.pgpass_credentials[pg_map_keys[key]] == "*" or self.pgpass_credentials[pg_map_keys[key]] == "":
+                            self.opts[key] = pgpass_credentials[pg_map_keys[key]]
 
     def create_db_statement(self):
         """In PostgreSQL, the equivalent of a SQL database is a schema."""
@@ -138,7 +150,7 @@ CSV HEADER;"""
            Please update the encoding lookup table if the required encoding is not present.
         """
         import psycopg2 as dbapi
-        self.get_input()
+        self.check_credentials()
         conn = dbapi.connect(host=self.opts["host"],
                              port=int(self.opts["port"]),
                              user=self.opts["user"],

--- a/retriever/engines/postgres.py
+++ b/retriever/engines/postgres.py
@@ -1,7 +1,8 @@
 import os
+import io
 from retriever.lib.models import Engine, no_cleanup
-from retriever import ENCODING
-
+from retriever import ENCODING, PGPASS_FILE_PATH
+import io
 
 class engine(Engine):
     """Engine instance for PostgreSQL."""
@@ -17,21 +18,30 @@ class engine(Engine):
         "bool": "boolean",
     }
     max_int = 2147483647
+    try:
+        pgpass_file = io.open(PGPASS_FILE_PATH, 'r')
+        pgpass_credentials = pgpass_file.split(':') # Split the credentials file of the format hostname:port:database:username:password
+        pgpass_lookup = {'username': pgpass_credentials[3], 'password': pgpass_credentials[4], 'host': pgpass_credentials[0], 'port': pgpass_credentials[1], 'database': pgpass_credentials[2]}
+    except IOError:
+        pgpass_lookup = {'username': "postgres", 'password': "", 'host': "localhost", 'port': 5432, 'database': "postgres"}
+
+    for key in pgpass_lookup.keys():
+        if pgpass_lookup[key] == "*" : pgpass_lookup[key] = ""
     required_opts = [("user",
                       "Enter your PostgreSQL username",
-                      "postgres"),
+                      pgpass_lookup['username']),
                      ("password",
                       "Enter your password",
-                      ""),
+                      pgpass_lookup['password']),
                      ("host",
                       "Enter your PostgreSQL host",
-                      "localhost"),
+                      pgpass_lookup['host']),
                      ("port",
                       "Enter your PostgreSQL port",
-                      5432),
+                      pgpass_lookup['port']),
                      ("database",
                       "Enter your PostgreSQL database name",
-                      "postgres"),
+                      pgpass_lookup['database']),
                      ("database_name",
                       "Format of schema name",
                       "{db}"),

--- a/retriever/lib/engine.py
+++ b/retriever/lib/engine.py
@@ -601,6 +601,16 @@ class Engine(object):
             if self.opts[opt[0]] in ["", "default"]:
                 self.opts[opt[0]] = opt[2]
 
+    def check_credentials(self):
+        """
+        Checks the credentials of the user in the credentials file path for the database
+        credentials by checking the username provided by the user in cli.
+        If found, it updates the credentials to initialize the connection, else uses the
+        default ones.
+        This method has been overidden in different engines accordingly.
+        """
+        pass
+
     def insert_data_from_archive(self, url, filenames):
         """Insert data from files located in an online archive. This function
         extracts the file, inserts the data, and deletes the file if raw data


### PR DESCRIPTION
@henrykironde @ethanwhite I have edited the mysql and postgres engines for looking up and falling back to the default credentials provided in the configuration files of the respective databases. The searching method looks a bit untidy in mysql engine, I would love some suggestions on that part. Also I thought of overriding the `get_input()` function but I cleaned up the inputs in postgres. Kindly review the code and suggest any changes I can start working on :smile: 