### PR TITLE
Improving --not-cached option functionality

### DIFF
--- a/retriever/__main__.py
+++ b/retriever/__main__.py
@@ -175,9 +175,9 @@ def main():
             sys.tracebacklimit = 0
 
         if hasattr(args, 'debug') and args.not_cached:
-            use_cache = False
+            engine.use_cache = False
         else:
-            use_cache = True
+            engine.use_cache = True
 
         if args.dataset is not None:
             scripts = name_matches(script_list, args.dataset)
@@ -187,7 +187,7 @@ def main():
             for dataset in scripts:
                 print("=> Installing", dataset.name)
                 try:
-                    dataset.download(engine, debug=debug, use_cache=use_cache)
+                    dataset.download(engine, debug=debug)
                     dataset.engine.final_cleanup()
                 except KeyboardInterrupt:
                     pass

--- a/retriever/engines/download_only.py
+++ b/retriever/engines/download_only.py
@@ -97,13 +97,13 @@ class engine(Engine):
             # If the file doesn't exist, download it
             self.download_file(url, filename)
 
-    def insert_data_from_url(self, url, use_cache=True):
+    def insert_data_from_url(self, url):
         """Insert data from a web resource"""
         filename = filename_from_url(url)
         find = self.find_file(filename)
         if not find:
             self.create_raw_data_dir()
-            self.download_file(url, filename, use_cache)
+            self.download_file(url, filename)
 
     def find_file(self, filename):
         """Checks for the given file and adds it to the list of all files"""

--- a/retriever/lib/engine.py
+++ b/retriever/lib/engine.py
@@ -37,6 +37,7 @@ class Engine(object):
     required_opts = []
     pkformat = "%s PRIMARY KEY %s "
     script = None
+    use_cache = True
     debug = False
     warnings = []
 
@@ -385,9 +386,9 @@ class Engine(object):
             db_name = name
         return db_name.replace('-', '_')
 
-    def download_file(self, url, filename, use_cache=True):
+    def download_file(self, url, filename):
         """Downloads a file to the raw data directory."""
-        if not self.find_file(filename) or not use_cache:
+        if not self.find_file(filename) or not self.use_cache:
             path = self.format_filename(filename)
             self.create_raw_data_dir()
             print("\nDownloading " + filename + "...")
@@ -399,6 +400,9 @@ class Engine(object):
                 # script. If this happens, fall back to the standard Python 2 version.
                 from urllib import urlretrieve as py2urlretrieve
                 py2urlretrieve(url, path, reporthook=reporthook)
+            finally:
+                # Download is complete, set to prevent repeated downloads
+                self.use_cache = True
 
     def download_files_from_archive(self, url, filenames, filetype="zip",
                                     keep_in_dir=False, archivename=None):
@@ -622,18 +626,18 @@ class Engine(object):
                         (self.load_data, (filename, ))))
         self.add_to_table(data_source)
 
-    def insert_data_from_url(self, url, use_cache=True):
+    def insert_data_from_url(self, url):
         """Insert data from a web resource, such as a text file."""
         filename = filename_from_url(url)
         find = self.find_file(filename)
-        if find and use_cache:
+        if find and self.use_cache:
             # Use local copy
             self.insert_data_from_file(find)
         else:
             # Save a copy of the file locally, then load from that file
             self.create_raw_data_dir()
             print("\nSaving a copy of " + filename + "...")
-            self.download_file(url, filename, use_cache)
+            self.download_file(url, filename)
             self.insert_data_from_file(self.find_file(filename))
 
     def insert_statement(self, values):

--- a/retriever/lib/templates.py
+++ b/retriever/lib/templates.py
@@ -39,10 +39,9 @@ class Script(object):
             desc += "\n" + self.reference_url()
         return desc
 
-    def download(self, engine=None, debug=False, use_cache=True):
+    def download(self, engine=None, debug=False):
         self.engine = self.checkengine(engine)
         self.engine.debug = debug
-        self.engine.use_cache = use_cache
         self.engine.db_name = self.shortname
         self.engine.create_db()
 
@@ -91,8 +90,8 @@ class BasicTextTemplate(Script):
     def __init__(self, **kwargs):
         Script.__init__(self, **kwargs)
 
-    def download(self, engine=None, debug=False, use_cache=True):
-        Script.download(self, engine, debug, use_cache)
+    def download(self, engine=None, debug=False):
+        Script.download(self, engine, debug)
 
         for key in list(self.urls.keys()):
             if key not in list(self.tables.keys()):
@@ -101,7 +100,7 @@ class BasicTextTemplate(Script):
 
         for key, value in list(self.urls.items()):
             self.engine.auto_create_table(self.tables[key], url=value)
-            self.engine.insert_data_from_url(value, use_cache)
+            self.engine.insert_data_from_url(value)
             self.tables[key].record_id = 0
         return self.engine
 
@@ -119,13 +118,13 @@ class DownloadOnlyTemplate(Script):
     def __init__(self, **kwargs):
         Script.__init__(self, **kwargs)
 
-    def download(self, engine=None, debug=False, use_cache=True):
+    def download(self, engine=None, debug=False):
         if engine.name != "Download Only":
             raise Exception("This dataset contains only non-tabular data files, and can only be used with the 'download only' engine.\nTry 'retriever download datasetname instead.")
-        Script.download(self, engine, debug, use_cache)
+        Script.download(self, engine, debug)
 
         for filename, url in self.urls.items():
-            self.engine.download_file(url, filename, use_cache)
+            self.engine.download_file(url, filename)
             if os.path.exists(self.engine.format_filename(filename)):
                 shutil.copy(self.engine.format_filename(filename), DATA_DIR)
             else:

--- a/scripts/vertnet_amphibians.py
+++ b/scripts/vertnet_amphibians.py
@@ -23,7 +23,7 @@ class main(Script):
         self.description = "Compilation of digitized museum records of amphibians including locations, dates of collection, and some trait data."
         self.tags = ['amphibians']
 
-    def download(self, engine=None, debug=False, use_cache=True):
+    def download(self, engine=None, debug=False):
         Script.download(self, engine, debug)
         engine = self.engine
 

--- a/scripts/vertnet_birds.py
+++ b/scripts/vertnet_birds.py
@@ -23,7 +23,7 @@ class main(Script):
         self.description = "Compilation of digitized museum records of birds including locations, dates of collection, and some trait data."
         self.tags = ['birds']
 
-    def download(self, engine=None, debug=False, use_cache=True):
+    def download(self, engine=None, debug=False):
         Script.download(self, engine, debug)
         engine = self.engine
 

--- a/scripts/vertnet_fishes.py
+++ b/scripts/vertnet_fishes.py
@@ -23,7 +23,7 @@ class main(Script):
         self.description = "Compilation of digitized museum records of fishes including locations, dates of collection, and some trait data."
         self.tags = ['fishes']
 
-    def download(self, engine=None, debug=False, use_cache=True):
+    def download(self, engine=None, debug=False):
         Script.download(self, engine, debug)
         engine = self.engine
 

--- a/scripts/vertnet_mammals.py
+++ b/scripts/vertnet_mammals.py
@@ -23,7 +23,7 @@ class main(Script):
         self.description = "Compilation of digitized museum records of mammals including locations, dates of collection, and some trait data."
         self.tags = ['mammals']
 
-    def download(self, engine=None, debug=False, use_cache=True):
+    def download(self, engine=None, debug=False):
         Script.download(self, engine, debug)
         engine = self.engine
 

--- a/scripts/vertnet_reptiles.py
+++ b/scripts/vertnet_reptiles.py
@@ -23,7 +23,7 @@ class main(Script):
         self.description = "Compilation of digitized museum records of reptiles including locations, dates of collection, and some trait data."
         self.tags = ['reptiles']
 
-    def download(self, engine=None, debug=False, use_cache=True):
+    def download(self, engine=None, debug=False):
         Script.download(self, engine, debug)
         engine = self.engine
 


### PR DESCRIPTION
#833 @ethanwhite @henrykironde 
Added ```engine.use_cache``` which allows for simpler and complete implementation of the ```--not-cached``` option.

To my knowledge there is still one unresolved problem in the code. It is for an exceptional usage of the ```--not-cached``` when there is no cache in the system and we are using the ```--not-cached``` option. In this case the files get downloaded twice.
The reason for this is in ```retriever/lib/templates.py``` the ```download``` function of ```BasicTextTemplate``` calls two functions of ```retriever/lib/engine.py``` one ```auto_create_table``` and another ```insert_data_from_url``` both of which are calling the ```download_file``` function.

The files don't get downloaded twice when ```--not-cached``` option is not specified because when ```download_file``` is called for the first time the data file is now present as cache for the next ```download_file``` call.
What should be done here?