### PR TITLE
Repair codecov coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ services:
   - postgresql
 install:
   - pip install -r requirements.txt
-  - python setup.py -q install
+  - pip install -e .
   - pip install codecov
   - pip install pytest-cov
   - pip install pytest-xdist


### PR DESCRIPTION
A recent change in the codecov service requires the project
to be installed in editable mode ``pip install -e .``
fixes #842