### PR TITLE
Move testing datasets from Ecological Archives to Figshare

### DIFF
--- a/scripts/bird_size.json
+++ b/scripts/bird_size.json
@@ -1,7 +1,7 @@
 {
     "citation": "Terje Lislevand, Jordi Figuerola, and Tamas Szekely. 2007. Avian body sizes in relation to fecundity, mating system, display behavior, and resource sharing. Ecology 88:1605.",
     "description": "A comprehensive compilation of data set on avian body sizes that would be useful for future comparative studies of avian biology.",
-    "homepage": "http://esapubs.org/archive/ecol/E088/096/",
+    "homepage": "https://figshare.com/articles/Data_Paper_Data_Paper/3527864",
     "keywords": [
         "birds",
         "literature-compilation"
@@ -16,14 +16,14 @@
             },
             "name": "species",
             "schema": {},
-            "url": "http://esapubs.org/archive/ecol/E088/096/avian_ssd_jan07.txt"
+            "url": "https://ndownloader.figshare.com/files/5599229"
         }
     ],
     "retriever": "True",
     "retriever_minimum_version": "2.0.dev",
     "title": "Bird Body Size and Life History (Lislevand et al. 2007)",
     "urls": {
-        "species": "http://esapubs.org/archive/ecol/E088/096/avian_ssd_jan07.txt"
+        "species": "https://ndownloader.figshare.com/files/5599229"
     },
-    "version": "1.1.1"
+    "version": "1.2.0"
 }

--- a/scripts/mammal_masses.json
+++ b/scripts/mammal_masses.json
@@ -1,7 +1,7 @@
 {
     "citation": "Felisa A. Smith, S. Kathleen Lyons, S. K. Morgan Ernest, Kate E. Jones, Dawn M. Kaufman, Tamar Dayan, Pablo A. Marquet, James H. Brown, and John P. Haskell. 2003. Body mass of late Quaternary mammals. Ecology 84:3403.",
     "description": "A data set of compiled body mass information for all mammals on Earth.",
-    "homepage": "http://www.esapubs.org/archive/ecol/E084/094/",
+    "homepage": "https://figshare.com/articles/Data_Paper_Data_Paper/3523112",
     "keywords": [
         "mammals",
         "literature-compilation",
@@ -67,14 +67,14 @@
                     }
                 ]
             },
-            "url": "http://www.esapubs.org/Archive/ecol/E084/094/MOMv3.3.txt"
+            "url": "https://ndownloader.figshare.com/files/5593343"
         }
     ],
     "retriever": "True",
     "retriever_minimum_version": "2.0.dev",
     "title": "Masses of Mammals (Smith et al. 2003)",
     "urls": {
-        "MammalMasses": "http://www.esapubs.org/Archive/ecol/E084/094/MOMv3.3.txt"
+        "MammalMasses": "https://ndownloader.figshare.com/files/5593343"
     },
-    "version": "1.2.1"
+    "version": "1.3.0"
 }

--- a/scripts/mt_st_helens_veg.json
+++ b/scripts/mt_st_helens_veg.json
@@ -1,7 +1,7 @@
 {
     "citation": "Roger del Moral. 2010. Thirty years of permanent vegetation plots, Mount St. Helens, Washington. Ecology 91:2185.",
     "description": "Documenting vegetation recovery from volcanic disturbances using the most common species found in non-forested habitats on Mount St. Helens.",
-    "homepage": "http://esapubs.org/archive/ecol/E091/152/",
+    "homepage": "https://figshare.com/collections/Thirty_years_of_permanent_vegetation_plots_Mount_St_Helens_Washington_USA/3303093",
     "keywords": [
         "plants",
         "local-scale",
@@ -133,13 +133,13 @@
                     }
                 ]
             },
-            "url": "http://esapubs.org/archive/ecol/E091/152/MSH_SPECIES_PLOT_YEAR.csv"
+            "url": "https://ndownloader.figshare.com/files/5613783"
         },
         {
             "dialect": {},
             "name": "structure_plot_year",
             "schema": {},
-            "url": "http://esapubs.org/archive/ecol/E091/152/MSH_STRUCTURE_PLOT_YEAR.csv"
+            "url": "https://ndownloader.figshare.com/files/5613786"
         },
         {
             "dialect": {
@@ -148,23 +148,23 @@
             },
             "name": "species",
             "schema": {},
-            "url": "http://esapubs.org/archive/ecol/E091/152/MSH_SPECIES_DESCRIPTORS.csv"
+            "url": "https://ndownloader.figshare.com/files/5613789"
         },
         {
             "dialect": {},
             "name": "plots",
             "schema": {},
-            "url": "http://esapubs.org/archive/ecol/E091/152/MSH_PLOT_DESCRIPTORS.csv"
+            "url": "https://ndownloader.figshare.com/files/5613792"
         }
     ],
     "retriever": "True",
     "retriever_minimum_version": "2.0.dev",
     "title": "Mount St. Helens vegetation recovery plots (del Moral 2010)",
     "urls": {
-        "plots": "http://esapubs.org/archive/ecol/E091/152/MSH_PLOT_DESCRIPTORS.csv",
-        "species": "http://esapubs.org/archive/ecol/E091/152/MSH_SPECIES_DESCRIPTORS.csv",
-        "species_plot_year": "http://esapubs.org/archive/ecol/E091/152/MSH_SPECIES_PLOT_YEAR.csv",
-        "structure_plot_year": "http://esapubs.org/archive/ecol/E091/152/MSH_STRUCTURE_PLOT_YEAR.csv"
+        "plots": "https://ndownloader.figshare.com/files/5613792",
+        "species": "https://ndownloader.figshare.com/files/5613789",
+        "species_plot_year": "https://ndownloader.figshare.com/files/5613783",
+        "structure_plot_year": "https://ndownloader.figshare.com/files/5613786"
     },
-    "version": "1.1.1"
+    "version": "1.2.0"
 }

--- a/test/test_regression_cli.py
+++ b/test/test_regression_cli.py
@@ -29,8 +29,8 @@ working_script_dir = os.path.abspath(os.path.join(retriever_root_dir, "scripts")
 HOMEDIR = os.path.expanduser('~')
 
 download_md5 = [
-    ('mt-st-helens-veg', '9f81bbccfd6a99938e5455a489fdb7b5'),
-    ('bird-size', 'dce81ee0f040295cd14c857c18cc3f7e'),
+    ('mt-st-helens-veg', 'd5782e07241cb3fe9f5b2e1bb804a794'),
+    ('bird-size', '45c7507ae945868c71b5179f7682ea9c'),
     ('mammal-masses', 'b54b80d0d1959bdea0bb8a59b70fa871')
 ]
 


### PR DESCRIPTION
The datasets from ecologial Archieves have been moved to a much more stable environment, Figshare.