### PR TITLE
Move fish-parasite-hosts links from Ecological Archives to figshare

### DIFF
--- a/scripts/fish_parasite_hosts.json
+++ b/scripts/fish_parasite_hosts.json
@@ -1,6 +1,7 @@
 {
     "citation": "Giovanni Strona, Maria Lourdes D. Palomares, Nicolas Bailly, Paolo Galli, and Kevin D. Lafferty. 2013. Host range, host ecology, and distribution of more than 11800 fish parasite species. Ecology 94:544.",
     "description": "The data set includes 38008 fish parasite records (for Acanthocephala, Cestoda, Monogenea, Nematoda, Trematoda) compiled from scientific literature.",
+    "homepage": "https://figshare.com/articles/Data_Paper_Data_Paper/3555378",
     "name": "fish-parasite-hosts",
     "resources": [
         {
@@ -89,14 +90,14 @@
             },
             "name": "host_characteristics",
             "schema": {},
-            "url": "http://esapubs.org/archive/ecol/E094/045/FPEDB.csv"
+            "url": "https://ndownloader.figshare.com/files/5624799"
         }
     ],
     "retriever": "True",
     "retriever_minimum_version": "2.0.dev",
     "title": "Fish parasite host ecological characteristics (Strona, et al., 2013)",
     "urls": {
-        "host_characteristics": "http://esapubs.org/archive/ecol/E094/045/FPEDB.csv"
+        "host_characteristics": "https://ndownloader.figshare.com/files/5624799"
     },
-    "version": "1.1.1"
+    "version": "1.2.0"
 }

--- a/version.txt
+++ b/version.txt
@@ -13,7 +13,7 @@ butterfly_population_network.json,1.1.1
 car_eval.json,1.1.1
 community_abundance_misc.json,1.0.1
 elton_traits.json,1.1.1
-fish_parasite_hosts.json,1.1.1
+fish_parasite_hosts.json,1.2.0
 forest_biomass_china.json,1.1.1
 forest_fires_portugal.json,1.1.3
 forest_inventory_analysis.py,1.3.1


### PR DESCRIPTION
The old Ecological Archives is now unstable.