### PR TITLE
Update metadata for portal-dev

### DIFF
--- a/scripts/portal-dev.json
+++ b/scripts/portal-dev.json
@@ -1,7 +1,7 @@
 {
-    "citation": "S. K. Morgan Ernest, Thomas J. Valone, and James H. Brown. 2009. Long-term monitoring and experimental manipulation of a Chihuahuan Desert ecosystem near Portal, Arizona, USA. Ecology 90:1708.",
-    "description": "The data set represents a Desert ecosystems using the composition and abundances of ants, plants, and rodents has occurred continuously on 24 plots. Currently includes only mammal data.",
-    "homepage": "http://esapubs.org/archive/ecol/E090/118/",
+    "citation": "S. K. M. Ernest, G. M. Yenni, G. Allington, E. M. Christensen, K. Geluso, J. R. Goheen, M. R. Schutzenhofer, S. R. Supp, K. M. Thibault, James H. Brown, and T. J. Valone. 2016. Long-term monitoring and experimental manipulation of a Chihuahuan desert ecosystem near Portal, Arizona (1977–2013). Ecology 97:1082.",
+    "description": "The data set represents a Desert ecosystems using the composition and abundances of ants, plants, and rodents has occurred continuously on 24 plots.",
+    "homepage": "https://github.com/weecology/PortalData",
     "keywords": [
         "mammals",
         "desert",
@@ -645,7 +645,7 @@
     ],
     "retriever": "True",
     "retriever_minimum_version": "2.0.dev",
-    "title": "Portal Project Data (Ernest et al. 2009)",
+    "title": "Portal Project Data (Ernest et al. 2016)",
     "urls": {
         "rodent": "https://raw.githubusercontent.com/weecology/PortalData/master/Rodents/Portal_rodent.csv",
         "rodent_species" : "https://raw.githubusercontent.com/weecology/PortalData/master/Rodents/Portal_rodent_species.csv",
@@ -663,5 +663,5 @@
         "weather_19801989":"https://raw.githubusercontent.com/weecology/PortalData/master/Weather/Portal_weather_19801989.csv",
         "weather":"https://raw.githubusercontent.com/weecology/PortalData/master/Weather/Portal_weather.csv"
     },
-    "version": "1.0.0"
+    "version": "1.0.1"
 }

--- a/version.txt
+++ b/version.txt
@@ -46,7 +46,7 @@ plant_life_hist_eu.py,1.3.1
 plant_occur_oosting.json,1.2.0
 plant_taxonomy_us.json,1.1.2
 poker_hands.json,1.2.1
-portal-dev.json,1.0.0
+portal-dev.json,1.0.1
 portal.json,1.2.0
 predator_prey_size_marine.json,1.1.1
 prism_climate.py,1.1.1


### PR DESCRIPTION
* Update the citation to the newest data paper
* Update the homepage to the GitHub repository (which also gets rid of the unstable Ecological Archive link)
* Update the title with the new year
* Update the description to not include the (old) limitation to rodents