### PR TITLE
Re-add high speed bulk importing for SQLite

### DIFF
--- a/retriever/engines/sqlite.py
+++ b/retriever/engines/sqlite.py
@@ -52,6 +52,45 @@ class engine(Engine):
         insert_stmt = insert_stmt.rstrip(", ") + ")"
         return insert_stmt
 
+    def insert_data_from_file(self, filename):
+        """Perform a high speed bulk insert
+
+        Checks to see if a given file can be bulk inserted, and if so loads
+        it in chunks and inserts those chunks into the database using
+        executemany.
+        """
+        CHUNK_SIZE = 1000000
+        self.get_cursor()
+
+        # Determine if the dataset includes cross-tab data
+        crosstab = len([True for c in self.table.columns if c[1][0][:3] == "ct-"]) != 0
+
+        if (([self.table.cleanup.function, self.table.header_rows] == [no_cleanup, 1])
+            and not self.table.fixed_width
+            and not crosstab
+            and (not hasattr(self.table, "do_not_bulk_insert") or not self.table.do_not_bulk_insert)
+            ):
+            columns = self.table.get_insert_columns()
+            filename = os.path.abspath(filename)
+            try:
+                bulk_insert_statement = self.get_bulk_insert_statement()
+                line_endings = set(['\n', '\r', '\r\n'])
+                with open(filename, 'r') as data_file:
+                    data_chunk = data_file.readlines(CHUNK_SIZE)
+                    data_chunk = [line.rstrip('\r\n') for line in data_chunk if line not in line_endings]
+                    del(data_chunk[:self.table.header_rows])
+                    while data_chunk:
+                        data_chunk_split = [row.split(self.table.delimiter)
+                                            for row in data_chunk]
+                        self.cursor.executemany(bulk_insert_statement, data_chunk_split)
+                        data_chunk = data_file.readlines(CHUNK_SIZE)
+                self.connection.commit()
+            except:
+                self.connection.rollback()
+                return Engine.insert_data_from_file(self, filename)
+        else:
+            return Engine.insert_data_from_file(self, filename)
+
     def table_exists(self, dbname, tablename):
         """Determine if the table already exists in the database"""
         if not hasattr(self, 'existing_table_names'):


### PR DESCRIPTION
This was originally added in bc182e4 and then removed in defdea4 because
we thought all of the functionality had been moved into the main `add_to_table`
code. However the speed-ups dropped off substantially with that move. We thought
this was due to the need to restrict the number of inserted rows due to other engines
but that turns out not to be the case. There are differences in how inserts are handled
by this code since it can assume data that doesn't need to be cleaned, specifically
chunked line reading (and possibly the parameter binding). This restores the code to
it's previous form so that the bulk inserts work quickly again. This is on the order of a
20x speed up for large clean datasets.