### PR TITLE
One way to resolve long imports

### DIFF
--- a/retriever/lib/__init__.py
+++ b/retriever/lib/__init__.py
@@ -1,2 +1,3 @@
 
 """retriever.lib contains the core Data Retriever modules."""
+from .datasets import datasets

--- a/retriever/lib/datasets.py
+++ b/retriever/lib/datasets.py
@@ -1,4 +1,4 @@
-from retriever import SCRIPT_LIST
+from retriever.lib.testing_func import SCRIPT_LIST
 
 
 def datasets(arg_script=None):

--- a/retriever/lib/testing_func.py
+++ b/retriever/lib/testing_func.py
@@ -1,25 +1,12 @@
-"""Data Retriever
-
-This package contains a framework for creating and running scripts designed to
-download published ecological data, and store the data in a database.
-
-"""
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import str
-
-import io
-import os
-import sys
-import csv
 from os.path import join, isfile, getmtime, exists
 from pkg_resources import parse_version
 import imp
+import os
 import platform
+import sys
 
 from retriever.lib.compile import compile_json
 from retriever._version import __version__
-from .lib import *
 
 current_platform = platform.system().lower()
 if current_platform != 'windows':
@@ -32,8 +19,6 @@ MASTER_BRANCH = REPO_URL + "master/"
 REPOSITORY = MASTER_BRANCH
 ENCODING = 'ISO-8859-1'
 
-# create the necessary directory structure for storing scripts/raw_data
-# in the ~/.retriever directory
 HOME_DIR = os.path.expanduser('~/.retriever/')
 for dir in (HOME_DIR, os.path.join(HOME_DIR, 'raw_data'), os.path.join(HOME_DIR, 'scripts')):
     if not os.path.exists(dir):
@@ -63,62 +48,6 @@ DATA_WRITE_PATH = DATA_SEARCH_PATHS[-1]
 
 # Create default data directory
 DATA_DIR = '.'
-
-
-def open_fr(file_name, encoding=ENCODING, encode=True):
-    """Open file for reading respecting Python version and OS differences
-
-    Sets newline to Linux line endings on Windows and Python 3
-    When encode=False does not set encoding on nix and Python 3 to keep as bytes
-    """
-    if sys.version_info >= (3, 0, 0):
-        if os.name == 'nt':
-            file_obj = io.open(file_name, 'r', newline='', encoding=encoding)
-        else:
-            if encode:
-                file_obj = io.open(file_name, "r", encoding=encoding)
-            else:
-                file_obj = io.open(file_name, "r")
-    else:
-        file_obj = io.open(file_name, "r", encoding=encoding)
-    return file_obj
-
-
-def open_fw(file_name, encoding=ENCODING, encode=True):
-    """Open file for writing respecting Python version and OS differences
-
-    Sets newline to Linux line endings on Python 3
-    When encode=False does not set encoding on nix and Python 3 to keep as bytes
-    """
-    if sys.version_info >= (3, 0, 0):
-        if encode:
-            file_obj = io.open(file_name, 'w', newline='', encoding=encoding)
-        else:
-            file_obj = io.open(file_name, 'w', newline='')
-    else:
-        file_obj = io.open(file_name, 'wb',)
-    return file_obj
-
-
-def open_csvw(csv_file, encode=True):
-    """Open a csv writer forcing the use of Linux line endings on Windows
-
-    Also sets dialect to 'excel' and escape characters to '\\'
-
-    """
-    if os.name == 'nt':
-        csv_writer = csv.writer(csv_file, dialect='excel', escapechar='\\', lineterminator='\n')
-    else:
-        csv_writer = csv.writer(csv_file, dialect='excel', escapechar='\\')
-    return csv_writer
-
-
-def to_str(object, object_encoding=sys.stdout):
-    if sys.version_info >= (3, 0, 0):
-        enc = object_encoding.encoding
-        return str(object).encode(enc, errors='backslashreplace').decode("latin-1")
-    else:
-        return object
 
 
 def MODULE_LIST(force_compile=False):
@@ -152,7 +81,7 @@ def MODULE_LIST(force_compile=False):
                     if hasattr(new_module.SCRIPT, "retriever_minimum_version"):
                         # a script with retriever_minimum_version should be loaded
                         # only if its compliant with the version of the retriever
-                        if not parse_version(VERSION) >=  parse_version("{}".format(
+                        if not parse_version(VERSION) >= parse_version("{}".format(
                                 new_module.SCRIPT.retriever_minimum_version)):
                             print("{} is supported by Retriever version {}".format(script_name,
                                                                                    new_module.SCRIPT.retriever_minimum_version))
@@ -170,59 +99,3 @@ def MODULE_LIST(force_compile=False):
 
 def SCRIPT_LIST(force_compile=False):
     return [module.SCRIPT for module in MODULE_LIST(force_compile)]
-
-
-def ENGINE_LIST():
-    from retriever.engines import engine_list
-    return engine_list
-
-
-def set_proxy():
-    """Check for proxies and makes them available to urllib"""
-    proxies = ["https_proxy", "http_proxy", "ftp_proxy",
-               "HTTP_PROXY", "HTTPS_PROXY", "FTP_PROXY"]
-    for proxy in proxies:
-        if os.getenv(proxy):
-            if len(os.environ[proxy]) != 0:
-                for i in proxies:
-                    os.environ[i] = os.environ[proxy]
-                break
-
-set_proxy()
-
-sample_script = """
-{
-    "description": "S. K. Morgan Ernest. 2003. Life history characteristics of placental non-volant mammals. Ecology 84:3402.",
-    "homepage": "http://esapubs.org/archive/ecol/E084/093/default.htm",
-    "name": "MammalLH",
-    "resources": [
-        {
-            "dialect": {},
-            "mediatype": "text/csv",
-            "name": "species",
-            "schema": {},
-            "url": "http://esapubs.org/archive/ecol/E084/093/Mammal_lifehistories_v2.txt"
-        }
-    ],
-    "title": "Mammal Life History Database - Ernest, et al., 2003",
-    "urls": {
-        "species": "http://esapubs.org/archive/ecol/E084/093/Mammal_lifehistories_v2.txt"
-    }
-}
-"""
-CITATION = """Morris, B.D. and E.P. White. 2013. The EcoData Retriever: improving access to
-existing ecological data. PLOS ONE 8:e65848.
-http://doi.org/doi:10.1371/journal.pone.0065848
-
-@article{morris2013ecodata,
-  title={The EcoData Retriever: Improving Access to Existing Ecological Data},
-  author={Morris, Benjamin D and White, Ethan P},
-  journal={PLOS One},
-  volume={8},
-  number={6},
-  pages={e65848},
-  year={2013},
-  publisher={Public Library of Science}
-  doi={10.1371/journal.pone.0065848}
-}
-"""


### PR DESCRIPTION
This way the `datasets` import will become:
```python
import retriever as ret
ret.datasets()
```

This requires the functions `__init__.py` to be moved into separate modules. I envision the `__init__.py` without any function. Just function calls.
This change will also require updating the relative paths to these functions. @henrykironde 