### PR TITLE
Reference `keywords` in scripts before replacing for 2.0.0

### DIFF
--- a/scripts/flensburg_food_web.py
+++ b/scripts/flensburg_food_web.py
@@ -14,8 +14,9 @@ class main(Script):
         self.shortname="flensburg-food-web"
         self.ref="https://figshare.com/articles/Full_Archive/3552066"
         self.description="This data is of a food web for the Flensburg Fjord, a brackish shallow water inlet on the Baltic Sea, between Germany and Denmark."
+        self.keywords = []
         self.retriever_minimum_version='2.0.dev'
-        self.version='1.0.0'
+        self.version='1.0.1'
         self.urls={"zip": "https://ndownloader.figshare.com/files/5620326"}
         self.cleanup_func_table = Cleanup(correct_invalid_value, missing_values=[''])
 

--- a/scripts/socean_diet_data.py
+++ b/scripts/socean_diet_data.py
@@ -14,8 +14,9 @@ class main(Script):
         self.shortname="socean-diet-data"
         self.ref="https://figshare.com/articles/Full_Archive/3551304"
         self.description="Diet-related data from published and unpublished data sets and studies"
+        self.keywords = []
         self.retriever_minimum_version='2.0.dev'
-        self.version='1.0.0'
+        self.version='1.0.1'
         self.urls={"zip": "https://ndownloader.figshare.com/files/5618823"}
         self.cleanup_func_table = Cleanup(correct_invalid_value, missing_values=['', 'unknown'])
 

--- a/version.txt
+++ b/version.txt
@@ -18,7 +18,7 @@ community_abundance_misc.json,1.0.1
 dicerandra_frutescens.json,1.0.0
 elton_traits.json,1.2.0
 fish_parasite_hosts.json,1.2.0
-flensburg_food_web.py,1.0.0
+flensburg_food_web.py,1.0.1
 forest_biomass_china.json,1.2.0
 forest_fires_portugal.json,1.1.3
 forest_inventory_analysis.py,1.4.0
@@ -63,7 +63,7 @@ portal.json,1.2.0
 predator_prey_body_ratio.json,1.0.0
 predator_prey_size_marine.py,2.0.0
 prism_climate.py,1.2.0
-socean_diet_data.py,1.0.0
+socean_diet_data.py,1.0.1
 species_exctinction_rates.json,1.0.0
 streamflow_conditions.json,1.0.0
 tree_canopy_geometries.json,1.0.0


### PR DESCRIPTION
The standard 2.0.0 backward compatibility code changes `keywords` to `tags`
but this requires that `keywords` be defined.

Fixes #931. Replaces #932.