### PR TITLE
[WIP] Add ability to use existing data packages

### DIFF
--- a/retriever/lib/compile.py
+++ b/retriever/lib/compile.py
@@ -129,8 +129,17 @@ def compile_json(json_file):
             # Adding the key 'encoding'
             source_encoding = str(value)
 
+        elif key == "retriever":
+            values["retriever"] = value
+
         elif key == "retriever_minimum_version":
             values["retriever_minimum_version"] = "\"" + str(value) + "\""
+
+        elif key == "urls":
+            values["urls"] == value
+
+        elif key == "scan_lines":
+            values["scan_lines"] = value
 
         elif key == "message":
             values["message"] = "\"" + str(value) + "\""
@@ -160,9 +169,7 @@ def compile_json(json_file):
                         add_schema(table_dict, table)
 
                 tables[table["name"]] = table_dict
-
-        else:
-            values[key] = value 
+            
     # Create a Table object string using the tables dict
     table_desc = "{"
     for (key, value) in tables.items():

--- a/retriever/lib/get_datapackages.py
+++ b/retriever/lib/get_datapackages.py
@@ -48,6 +48,26 @@ def add_retriever_metadata(dp):
     dp["retriever_minimum_version"] = "2.0.0"
     return dp
 
+def match_types(dp):
+    """Match the datapackage types to the retriever types
+
+    The retriever still describes types using its old system instead of the
+    official frictionless data spec. This converts frictionless data types to
+    retriever types.
+
+    """
+
+    types = {'string': 'char',
+             'number': 'double',
+             'integer': 'int',
+             'date': 'char'
+    }
+
+    for resource in dp['resources']:
+        for field in resource['schema']['fields']:
+            field['type'] = types.get(field['type'], field['type'])
+    return dp
+
 def download_dps_json(dps):
     """Download json files for each external data package"""
     scripts_dir = os.path.join(HOME_DIR, 'scripts')
@@ -57,6 +77,7 @@ def download_dps_json(dps):
         url = dps[dp_name]
         dp = load_dp_json(url)
         dp = replace_path(dp, url)
+        dp = match_types(dp)
         dp = add_retriever_metadata(dp)
         write_path = os.path.join(scripts_dir,
                                   dp_name.replace('-', '_') + ".json")

--- a/retriever/lib/get_datapackages.py
+++ b/retriever/lib/get_datapackages.py
@@ -48,6 +48,16 @@ def add_retriever_metadata(dp):
     dp["retriever_minimum_version"] = "2.0.0"
     return dp
 
+def replace_name(dp, dp_name):
+    """Replace the original dp name with the name chosen for the retriever
+
+    There is no system for ensuring that data package names are unique and
+    descriptive, so we replace the name in the original dp with the name
+    specified in datapackage.yml
+    """
+    dp["name"] = dp_name
+    return dp
+
 def match_types(dp):
     """Match the datapackage types to the retriever types
 
@@ -77,6 +87,7 @@ def download_dps_json(dps):
         url = dps[dp_name]
         dp = load_dp_json(url)
         dp = replace_path(dp, url)
+        dp = replace_name(dp, dp_name)
         dp = match_types(dp)
         dp = add_retriever_metadata(dp)
         write_path = os.path.join(scripts_dir,

--- a/retriever/lib/get_datapackages.py
+++ b/retriever/lib/get_datapackages.py
@@ -1,0 +1,64 @@
+import os.path
+import yaml
+import json
+from urllib.request import urlopen
+from urllib.parse import urljoin, urlparse, urlunparse, ParseResult
+
+from retriever import HOME_DIR, SCRIPT_SEARCH_PATHS
+
+def get_dps():
+    """Load the list of data packages from datapackages.yml
+
+    Checks all of the search paths for a datapackages.yml file and loads it into
+    a dictionary.
+
+    """
+    for path in SCRIPT_SEARCH_PATHS:
+        try:
+            with open(os.path.join(path, "datapackages.yml"), 'r') as dp_file:
+                dp_dict = yaml.safe_load(dp_file)
+        except:
+            pass
+    return dp_dict
+
+def load_dp_json(url):
+    """Load a remote data package json file"""
+    with urlopen(url) as url:
+        dp = json.loads(url.read().decode())
+    return dp
+
+def replace_path(dp, url):
+    """Replace relative data locations with absolute urls
+
+    Data packages can either use relative paths or absolute urls to identify the
+    locations of data: http://frictionlessdata.io/guides/data-package/#resources
+    Convert all of the relative paths into absolute urls for consistent
+    processing
+
+    """
+    for resource in dp['resources']:
+        if 'path' in resource:
+            resource['url'] = urljoin(url, resource['path'])
+            del resource['path']
+    return dp
+
+def add_retriever_metadata(dp):
+    """Add retriever specific metadata to a data package json file"""
+    dp["retriever"] = "True"
+    dp["retriever_minimum_version"] = "2.0.0"
+    return dp
+
+def download_dps_json(dps):
+    """Download json files for each external data package"""
+    scripts_dir = os.path.join(HOME_DIR, 'scripts')
+    if not os.path.exists(scripts_dir):
+        os.makedirs(scripts_dir)
+    for dp_name in dps:
+        url = dps[dp_name]
+        dp = load_dp_json(url)
+        dp = replace_path(dp, url)
+        dp = add_retriever_metadata(dp)
+        write_path = os.path.join(scripts_dir,
+                                  dp_name.replace('-', '_') + ".json")
+        with open(write_path, 'w') as fp:
+            json.dump(dp, fp, sort_keys=True, indent=4, separators=(',', ':'))

--- a/retriever/lib/repository.py
+++ b/retriever/lib/repository.py
@@ -11,6 +11,7 @@ import imp
 from pkg_resources import parse_version
 from retriever import REPOSITORY, SCRIPT_WRITE_PATH, HOME_DIR
 from retriever.lib.models import file_exists
+from retriever.lib import get_datapackages
 
 global abort, executable_name
 abort = False
@@ -26,6 +27,10 @@ def download_from_repository(filepath, newpath, repo=REPOSITORY):
         raise
         pass
 
+def download_external_dps():
+    """Downloads the current version of external data packages"""
+    dps = get_datapackages.get_dps()
+    get_datapackages.download_dps_json(dps)
 
 def check_for_updates():
     """Check for updates to scripts.
@@ -79,6 +84,10 @@ def check_for_updates():
                     print(e)
                     pass
             update_progressbar(float(index + 1) / float(total_script_count))
+        download_from_repository("scripts/" + "datapackages.yml",
+                                 os.path.normpath(os.path.join(SCRIPT_WRITE_PATH, "datapackages.yml")))
+        print("\nDownloading external data packages...")
+        download_external_dps()
     except:
         raise
         return

--- a/scripts/croche_vegetation_data.json
+++ b/scripts/croche_vegetation_data.json
@@ -38,7 +38,7 @@
     ],
     "retriever": "True",
     "retriever_minimum_version": "2.0.0-dev",
-    "script_version": 1.0,
+    "version": 1.0,
     "title": "Croche understory vegetation data set",
     "urls": {
         "croche_ba": "https://ndownloader.figshare.com/files/5600489",

--- a/scripts/datapackages.yml
+++ b/scripts/datapackages.yml
@@ -1,1 +1,3 @@
 gdp: https://raw.githubusercontent.com/datasets/gdp/master/datapackage.json
+country-codes: https://raw.githubusercontent.com/datasets/country-codes/master/datapackage.json
+population-density: https://raw.githubusercontent.com/datasets/population/master/datapackage.json

--- a/scripts/datapackages.yml
+++ b/scripts/datapackages.yml
@@ -1,3 +1,0 @@
-gdp: https://raw.githubusercontent.com/datasets/gdp/master/datapackage.json
-country-codes: https://raw.githubusercontent.com/datasets/country-codes/master/datapackage.json
-population-density: https://raw.githubusercontent.com/datasets/population/master/datapackage.json

--- a/scripts/datapackages.yml
+++ b/scripts/datapackages.yml
@@ -1,0 +1,1 @@
+gdp: https://raw.githubusercontent.com/datasets/gdp/master/datapackage.json

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ packages = [
 includes = [
     'xlrd',
     'future',
+    'pyyaml',
     'argcomplete',
     'pymysql',
     'psycopg2',
@@ -73,7 +74,8 @@ setup(name='retriever',
       install_requires=[
           'xlrd',
           'future',
-          'argcomplete'
+          'argcomplete',
+          'pyyaml'
       ],
 
       # py2app flags

--- a/version.txt
+++ b/version.txt
@@ -15,6 +15,7 @@ butterfly_population_network.json,1.2.0
 car_eval.json,1.1.1
 chytr_disease_distr.json,1.0.0
 community_abundance_misc.json,1.0.1
+croche_vegetation_data.json,1.0
 dicerandra_frutescens.json,1.0.0
 elton_traits.json,1.2.0
 fish_parasite_hosts.json,1.2.0


### PR DESCRIPTION
Downloads Frictionless Data data packages from the web and adds
them to the retriever. Accomplished by:

* Retrieving the JSON metadata file
* Modifying it to work with the retriever
* Writing it to the scripts directory

New packages are added by adding a name-url pair to
scripts/datapackages.yml.