### PR TITLE
modified the name_matches function 

### DIFF
--- a/retriever/__main__.py
+++ b/retriever/__main__.py
@@ -189,9 +189,7 @@ def main():
                         raise
             print("Done!")
         else:
-            print("The dataset {} isn't currently available in the Retriever".format(
-                args.dataset))
-            print("Run 'retriever ls to see a list of currently available datasets")
+            print("Run 'retriever ls' to see a list of currently available datasets.")
 
 
 if __name__ == "__main__":

--- a/retriever/lib/download.py
+++ b/retriever/lib/download.py
@@ -36,7 +36,6 @@ def download(dataset, path='./', quiet=False, subdir=False, debug=False):
                 if debug:
                     raise
     else:
-        message = "The dataset \"{}\" isn't currently available in the Retriever. " \
-                  "Run retriever.datasets() to see a list of currently " \
-                  "available datasets".format(args['dataset'])
+        message = "Run retriever.datasets() to see a list of currently " \
+                  "available datasets."
         raise ValueError(message)

--- a/retriever/lib/engine_tools.py
+++ b/retriever/lib/engine_tools.py
@@ -72,15 +72,15 @@ def name_matches(scripts, arg):
             return [script]
 
     for script in scripts:
-        max_ratio = max([difflib.SequenceMatcher(None, arg, factor).ratio() for factor in
-                         (script.name.lower(), script.title.lower(), script.filename.lower())] +
-                        [difflib.SequenceMatcher(None, arg, factor).ratio() for factor in
-                         [keyword.strip().lower() for keywordset in script.keywords for keyword in keywordset]]
-                        )
-        matches.append((script, max_ratio))
-    matches = [m for m in sorted(matches, key=lambda m: m[1], reverse=True) if m[1] > 0.6]
-    return [match[0] for match in matches]
+        script_match_ratio = difflib.SequenceMatcher(None, script.name, arg).ratio()
+        if  script_match_ratio >.53:
+            matches.append((script.name, script_match_ratio))
 
+    matches.sort(key=lambda x: -x[1])
+
+    print("\nThe dataset \"{}\" isn't currently available in the Retriever.".format(arg))
+    if matches:
+        print("Did you mean: \n\t{}".format("\n\t".join([i[0] for i in matches])))
 
 def final_cleanup(engine):
     """Perform final cleanup operations after all scripts have run."""

--- a/retriever/lib/install.py
+++ b/retriever/lib/install.py
@@ -31,9 +31,8 @@ def _install(args, use_cache, debug):
                 if debug:
                     raise
     else:
-        message = "The dataset \"{}\" isn't available in the Retriever. " \
-                  "Run retriever.datasets()to list the currently available " \
-                  "datasets".format(args['dataset'])
+        message = "Run retriever.datasets()to list the currently available " \
+                  "datasets."
         raise ValueError(message)
 
 


### PR DESCRIPTION
name_matches function now only checks for distances among script names and NOT keywords. This was made to address #1063. 

If the name matches exactly, the scripts are downloaded. If not, suggestions are given, but no scripts are downloaded. 

The constant of .53 for the levenshtein distance was arbitrarily chosen based on tests done by misspelling vertnet. 