### PR TITLE
Avoid bulk inserts for all integration tests

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -172,7 +172,7 @@ autopk_csv = {
                  '4,5,6'],
     'script': {"name": "autopk_csv",
                "resources": [
-                   {"dialect": {},
+                   {"dialect": {"do_not_bulk_insert": "True"},
                     "name": "autopk_csv",
                     "schema": {
                         "fields": [
@@ -212,7 +212,7 @@ crosstab = {
                  '1,2,2.1,2.2'],
     'script': {"name": "crosstab",
                "resources": [
-                   {"dialect": {},
+                   {"dialect": {"do_not_bulk_insert": "True"},
                     "name": "crosstab",
                     "schema": {
                         "ct_column": "c",
@@ -254,7 +254,7 @@ autopk_crosstab = {
                  '1,2,2.1,2.2'],
     'script': {"name": "autopk_crosstab",
                "resources": [
-                   {"dialect": {},
+                   {"dialect": {"do_not_bulk_insert": "True"},
                     "name": "autopk_crosstab",
                     "schema": {
                         "ct_column": "c",


### PR DESCRIPTION
I'm getting some local failures on MySQL for the few datasets that don't
avoid bulk inserts. It seems unlikely that these tests didn't avoid bulk
inserts on purpose so this makes all integration tests avoid them.