### PR TITLE
Adding a Singleton Class to prevent recompiling scripts

### DIFF
--- a/retriever/__main__.py
+++ b/retriever/__main__.py
@@ -19,7 +19,7 @@ from retriever.lib.datasets import datasets, dataset_names, license
 from retriever.lib.defaults import sample_script, CITATION, ENCODING, SCRIPT_SEARCH_PATHS
 from retriever.lib.get_opts import parser
 from retriever.lib.repository import check_for_updates
-from retriever.lib.scripts import SCRIPT_LIST, get_script
+from retriever.lib.scripts import SCRIPT_LIST, reload_scripts, get_script
 from retriever.lib.engine_tools import name_matches, reset_retriever
 
 
@@ -50,7 +50,7 @@ def main():
             parser.parse_args(['-h'])
 
         if hasattr(args, 'compile') and args.compile:
-            script_list = SCRIPT_LIST(force_compile=True)
+            script_list = reload_scripts()
 
         if args.command == 'defaults':
             for engine_item in engine_list:

--- a/retriever/compile.py
+++ b/retriever/compile.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from retriever.lib.scripts import MODULE_LIST
+from retriever.lib.scripts import reload_scripts
 
 
 def compile():
     print("Compiling retriever scripts...")
-    MODULE_LIST(force_compile=True)
+    reload_scripts()
     print("done.")
 
 

--- a/retriever/lib/download.py
+++ b/retriever/lib/download.py
@@ -23,7 +23,7 @@ def download(dataset, path='./', quiet=False, subdir=False, debug=False):
     script_list = SCRIPT_LIST()
     if not script_list or not os.listdir(SCRIPT_WRITE_PATH):
         check_for_updates()
-        script_list = SCRIPT_LIST(force_compile=False)
+        script_list = SCRIPT_LIST()
     scripts = name_matches(script_list, args['dataset'])
     if scripts:
         for script in scripts:

--- a/retriever/lib/engine_tools.py
+++ b/retriever/lib/engine_tools.py
@@ -289,10 +289,10 @@ def file_2list(input_file):
     return abs_list
 
 
-def get_module_version():
+def get_script_version():
     """This function gets the version number of the scripts and returns them in array form."""
-    from retriever.lib.scripts import MODULE_LIST
-    modules = MODULE_LIST()
+    from retriever.lib.scripts import SCRIPT_LIST
+    modules = SCRIPT_LIST()
     scripts = []
     for module in modules:
         if module.public:

--- a/retriever/lib/get_opts.py
+++ b/retriever/lib/get_opts.py
@@ -6,9 +6,9 @@ from argcomplete.completers import ChoicesCompleter
 
 from retriever.engines import engine_list
 from retriever.lib.defaults import VERSION
-from retriever.lib.scripts import MODULE_LIST
+from retriever.lib.scripts import SCRIPT_LIST
 
-module_list = MODULE_LIST()
+module_list = SCRIPT_LIST()
 script_list = [module.name for module in module_list]
 json_list = [module.name for module in module_list
              if os.path.isfile('.'.join(module._file.split('.')[:-1]) + '.json')]

--- a/retriever/lib/install.py
+++ b/retriever/lib/install.py
@@ -18,7 +18,7 @@ def _install(args, use_cache, debug):
     script_list = SCRIPT_LIST()
     if not script_list or not os.listdir(SCRIPT_WRITE_PATH):
         check_for_updates()
-        script_list = SCRIPT_LIST(force_compile=False)
+        script_list = SCRIPT_LIST()
     data_sets_scripts = name_matches(script_list, args['dataset'])
     if data_sets_scripts:
         for data_sets_script in data_sets_scripts:

--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -18,6 +18,7 @@ from pkg_resources import parse_version
 from retriever.lib.defaults import SCRIPT_SEARCH_PATHS, VERSION, ENCODING, SCRIPT_WRITE_PATH
 from retriever.lib.load_json import read_json
 
+global_script_list= {}
 
 def check_retriever_minimum_version(module):
     mod_ver = module.retriever_minimum_version
@@ -31,7 +32,7 @@ def check_retriever_minimum_version(module):
     return True
 
 
-def MODULE_LIST(force_compile=False):
+def reload_scripts():
     """Load scripts from scripts directory and return list of modules."""
     modules = []
     loaded_scripts = []
@@ -84,8 +85,10 @@ def MODULE_LIST(force_compile=False):
     return modules
 
 
-def SCRIPT_LIST(force_compile=False):
-    return [module for module in MODULE_LIST(force_compile)]
+def SCRIPT_LIST():
+    if global_script_list:
+        return global_script_list.get_scripts()
+    return reload_scripts()
 
 
 def get_script(dataset):
@@ -149,3 +152,13 @@ def to_str(object, object_encoding=sys.stdout):
         enc = object_encoding.encoding
         return str(object).encode(enc, errors='backslashreplace').decode("latin-1")
     return object
+
+class StoredScripts:
+
+    def __init__(self):
+        self._shared_scripts = SCRIPT_LIST()
+
+    def get_scripts(self):
+        return self._shared_scripts
+
+global_script_list = StoredScripts()

--- a/retriever/try_install_all.py
+++ b/retriever/try_install_all.py
@@ -15,7 +15,7 @@ import sys
 from imp import reload
 
 from retriever.engines import engine_list, choose_engine
-from retriever.lib.scripts import MODULE_LIST, SCRIPT_LIST
+from retriever.lib.scripts import SCRIPT_LIST
 
 reload(sys)
 if hasattr(sys, 'setdefaultencoding'):
@@ -25,7 +25,7 @@ if os.name == "nt":
 else:
     os_password = ""
 
-MODULE_LIST = MODULE_LIST()
+MODULE_LIST = SCRIPT_LIST()
 if len(sys.argv) > 1:
     engine_list = [
         e for e in engine_list

--- a/test/test_modified_scripts.py
+++ b/test/test_modified_scripts.py
@@ -16,8 +16,8 @@ from imp import reload
 from distutils.version import LooseVersion
 from retriever.engines import choose_engine, engine_list
 from retriever.lib.defaults import ENCODING
-from retriever.lib.scripts import MODULE_LIST, SCRIPT_LIST
-from retriever.lib.engine_tools import get_module_version
+from retriever.lib.scripts import SCRIPT_LIST
+from retriever.lib.engine_tools import get_script_version
 
 reload(sys)
 if hasattr(sys, 'setdefaultencoding'):
@@ -52,7 +52,7 @@ def get_modified_scripts():
     os.chdir(retriever_root_dir)
     modified_list = []
     version_file = urllib.request.urlopen("https://raw.githubusercontent.com/weecology/retriever/master/version.txt")
-    local_repo_scripts = get_module_version()  # local repo versions
+    local_repo_scripts = get_script_version()  # local repo versions
 
     upstream_versions = {}
     version_file.readline()
@@ -142,7 +142,7 @@ def install_modified():
                 test_engines[engine.abbreviation] = None
                 pass
 
-    module_list = MODULE_LIST()
+    module_list = SCRIPT_LIST()
     errors = []
     for module in module_list:
         for (key, value) in list(test_engines.items()):

--- a/version.py
+++ b/version.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import os
 
 from retriever.lib.defaults import VERSION
-from retriever.lib.engine_tools import get_module_version
+from retriever.lib.engine_tools import get_script_version
 
 
 def write_version_file(scripts):
@@ -20,7 +20,7 @@ def write_version_file(scripts):
 
 def update_version_file():
     """Update version.txt."""
-    scripts = get_module_version()
+    scripts = get_script_version()
     write_version_file(scripts)
     print("Version.txt updated.")
 


### PR DESCRIPTION
- Adding in a singleton class to prevent recompiling of scripts many times over in the same run. 
- MODULE_LIST() has been renamed to reload_json_scripts() to represent itself as a standalone function should we want to entirely reload all json scripts. 
- SCRIPT_LIST() has been modified to include an instance of our Singleton Class.

Based on orginal changes/discussions in #1010