### PR TITLE
Remove directory name from gentry-forecast-transects site code

### DIFF
--- a/scripts/gentry_forest_transects.py
+++ b/scripts/gentry_forest_transects.py
@@ -1,9 +1,6 @@
 #retriever
-"""Retriever script for Alwyn H. Gentry Forest Transect Dataset
+"""Retriever script for Alwyn H. Gentry Forest Transect Dataset"""
 
-"""
-from __future__ import print_function
-# from __future__ import unicode_literals
 from builtins import str
 from builtins import range
 
@@ -29,7 +26,7 @@ class main(Script):
         self.title = "Alwyn H. Gentry Forest Transect Dataset"
         self.name = "gentry-forest-transects"
         self.retriever_minimum_version = '2.0.dev'
-        self.version = '1.4.2'
+        self.version = '1.4.3'
         self.urls = {"stems": "http://www.mobot.org/mobot/gentry/123/all_Excel.zip",
                      "sites": "https://ndownloader.figshare.com/files/5515373",
                      "species": "",
@@ -74,7 +71,6 @@ U.S.A. """
         lines = []
         tax = []
         for filename in filelist:
-            print("Extracting data from " + filename + "...")
             book = xlrd.open_workbook(self.engine.format_filename(filename))
             sh = book.sheet_by_index(0)
             rows = sh.nrows
@@ -130,7 +126,8 @@ U.S.A. """
                         this_line["stems"] = [row[c]
                                               for c in cn["stems"]
                                               if not Excel.empty_cell(row[c])]
-                        this_line["site"] = filename[0:-4]
+                        site_code, _ = os.path.splitext(os.path.basename(filename))
+                        this_line["site"] = site_code
 
                         # Manually correct CEDRAL data, which has a single line
                         # that is shifted by one to the left starting at Liana
@@ -166,17 +163,11 @@ U.S.A. """
         tax_count = 0
 
         # Get all unique families/genera/species
-        print("\n")
         for group in tax:
             if not (group in unique_tax):
                 unique_tax.append(group)
                 tax_count += 1
                 tax_dict[group[0:3]] = tax_count
-                if tax_count % 10 == 0:
-                    msg = "Generating taxonomic groups: " + str(tax_count) + " / " + str(TAX_GROUPS)
-                    sys.stdout.flush()
-                    sys.stdout.write(msg + "\b" * len(msg))
-        print("\n")
         # Create species table
         table = Table("species", delimiter=",")
         table.columns=[("species_id"            ,   ("pk-int",)    ),

--- a/version.txt
+++ b/version.txt
@@ -29,7 +29,7 @@ forest_plots_michigan.json,1.2.1
 forest_plots_wghats.py,1.3.1
 fray_jorge_ecology.json,1.4.2
 gdp.json,1.0.2
-gentry_forest_transects.py,1.4.2
+gentry_forest_transects.py,1.4.3
 globi_interaction.json,1.0.1
 great_basin_mammal_abundance.json,1.0.1
 home_ranges.json,1.1.2


### PR DESCRIPTION
At some point a behavior changed that caused site names extracted from the file
names in gentry-forest-transects to including the directory in which they were
located. This leads to site_code values like africa/NDAKANNI. This commit
properly normalizes the path to get only the file name.

Also removes additional printing done in this script that is no longer desired.

Fixes #1144.