### PR TITLE
Fix argument name in download in templates.py

### DIFF
--- a/retriever/lib/templates.py
+++ b/retriever/lib/templates.py
@@ -118,7 +118,7 @@ class BasicTextTemplate(Script):
                 if hasattr(self, "archivename"):
                     archivename = self.archivename
                 self.engine.download_files_from_archive(url=url,
-                                                        filenames=files,
+                                                        file_names=files,
                                                         filetype=archive_type,
                                                         keep_in_dir=keep_in_dir,
                                                         archivename=archivename)


### PR DESCRIPTION
In engine.py the argument name is `file_names` in `download_files_from_archive` so I have fixed it in templates.py.