### PR TITLE
Add missing argument to fix three vertnet scripts

### DIFF
--- a/scripts/vertnet_fishes.py
+++ b/scripts/vertnet_fishes.py
@@ -22,7 +22,7 @@ class main(Script):
         self.title = "Vertnet Fishes"
         self.name = "vertnet-fishes"
         self.retriever_minimum_version = '2.0.dev'
-        self.version = '1.1.2'
+        self.version = '1.1.3'
         self.ref = "http://vertnet.org/resources/datatoolscode.html"
         self.urls = {
             'fishes': 'https://de.iplantcollaborative.org/anon-files//iplant/home/shared/commons_repo/curated/Vertnet_Fishes_Sep2016/VertNet_Fishes_Sept2016.zip'
@@ -243,7 +243,7 @@ class main(Script):
 
         engine.table = table
         if not os.path.isfile(engine.format_filename(filename)):
-            engine.download_files_from_archive(self.urls[tablename], [filename], "zip",
+            engine.download_files_from_archive(self.urls[tablename], [filename], "zip", False,
                                                "vertnet_latest_" + str(tablename))
         engine.create_table()
         engine.insert_data_from_file(engine.format_filename(str(filename)))

--- a/scripts/vertnet_mammals.py
+++ b/scripts/vertnet_mammals.py
@@ -22,7 +22,7 @@ class main(Script):
         self.title = "Vertnet Mammals"
         self.name = "vertnet-mammals"
         self.retriever_minimum_version = '2.0.dev'
-        self.version = '1.1.2'
+        self.version = '1.1.3'
         self.ref = "http://vertnet.org/resources/datatoolscode.html"
         self.urls = {
             'mammals': 'https://de.iplantcollaborative.org/anon-files//iplant/home/shared/commons_repo/curated/Vertnet_Mammalia_Sep2016/VertNet_Mammalia_Sept2016.zip',
@@ -246,6 +246,7 @@ class main(Script):
             engine.download_files_from_archive(self.urls[tablename],
                                                [filename],
                                                "zip",
+                                               False,
                                                "vertnet_latest_" + str(tablename))
         engine.create_table()
         engine.insert_data_from_file(engine.format_filename(str(filename)))

--- a/scripts/vertnet_reptiles.py
+++ b/scripts/vertnet_reptiles.py
@@ -22,7 +22,7 @@ class main(Script):
         self.title = "Vertnet Reptiles"
         self.name = "vertnet-reptiles"
         self.retriever_minimum_version = '2.0.dev'
-        self.version = '1.1.2'
+        self.version = '1.1.3'
         self.ref = "http://vertnet.org/resources/datatoolscode.html"
         self.urls = {
             'reptiles': 'https://de.iplantcollaborative.org/anon-files//iplant/home/shared/commons_repo/curated/Vertnet_Reptilia_Sep2016/VertNet_Reptilia_Sept2016.zip'
@@ -246,6 +246,7 @@ class main(Script):
             engine.download_files_from_archive(self.urls[tablename],
                                                [filename],
                                                "zip",
+                                               False,
                                                "vertnet_latest_" + str(tablename))
         engine.create_table()
         engine.insert_data_from_file(engine.format_filename(str(filename)))

--- a/version.txt
+++ b/version.txt
@@ -88,9 +88,9 @@ veg_plots_sdl.json,1.2.1
 vertnet.py,1.4.2
 vertnet_amphibians.py,1.1.2
 vertnet_birds.py,1.1.2
-vertnet_fishes.py,1.1.2
-vertnet_mammals.py,1.1.2
-vertnet_reptiles.py,1.1.2
+vertnet_fishes.py,1.1.3
+vertnet_mammals.py,1.1.3
+vertnet_reptiles.py,1.1.3
 wine_composition.json,1.1.1
 wine_quality.json,1.1.2
 wood_density.py,1.3.3


### PR DESCRIPTION
The scripts were missing the keep_in_dir argument for
download_files_from_archive(), which was causing the unzipped files
to end up in the wrong location and the installations to fail.