### PR TITLE
Add note on using system Python for building DEB

### DIFF
--- a/docs/Release.rst
+++ b/docs/Release.rst
@@ -25,6 +25,10 @@ Start
 Linux
 -----
 
+**Building the DEB package does not work using conda. If conda is your main**
+**Python change `python` in `build.sh` to `/usr/bin/python` or otherwise**
+**Adjust the path to use the system Python.**
+
 1. **Run the tests** (unless you just ran them on the same machine)
 2. Checkout master
 3. Run ``build.sh``


### PR DESCRIPTION
The `build.sh` script doesn't work properly with conda. This commit
adds a note to notify the developer of this and recommend ways to
avoid the problem if conda is the first Python on the path.