### PR TITLE
fixes to retriever ls after reset

### DIFF
--- a/retriever/__main__.py
+++ b/retriever/__main__.py
@@ -27,14 +27,15 @@ def main():
 
     else:
         # otherwise, parse them
-
-        if not os.path.isdir(SCRIPT_SEARCH_PATHS[1]) and not \
-                [f for f in os.listdir(SCRIPT_SEARCH_PATHS[-1])
-                 if os.path.exists(SCRIPT_SEARCH_PATHS[-1])]:
-            check_for_updates()
-        script_list = SCRIPT_LIST()
-
         args = parser.parse_args()
+
+        if args.command not in ['reset', 'update'] \
+        and not os.path.isdir(SCRIPT_SEARCH_PATHS[1]) \
+        and not [f for f in os.listdir(SCRIPT_SEARCH_PATHS[-1])
+            if os.path.exists(SCRIPT_SEARCH_PATHS[-1])]:
+                check_for_updates()
+                reload_scripts()
+        script_list = SCRIPT_LIST()
 
         if args.command == "install" and not args.engine:
             parser.parse_args(['install', '-h'])
@@ -57,8 +58,8 @@ def main():
             return
 
         if args.command == 'update':
-            check_for_updates(False)
-            script_list = SCRIPT_LIST()
+            check_for_updates()
+            reload_scripts()
             return
 
         elif args.command == 'citation':
@@ -114,11 +115,7 @@ def main():
             return
 
         if args.command == 'ls':
-            # If scripts have never been downloaded there is nothing to list
-            if not script_list:
-                print("No scripts are currently available. Updating scripts now...")
-                check_for_updates(False)
-                print("\n\nScripts downloaded.\n")
+            # scripts should never be empty because check_for_updates is run on SCRIPT_LIST init
             if not (args.l or args.k or isinstance(args.v, list)):
                 all_scripts = dataset_names()
                 print("Available datasets : {}\n".format(len(all_scripts)))

--- a/retriever/lib/__init__.py
+++ b/retriever/lib/__init__.py
@@ -13,12 +13,14 @@ from .install import install_xml
 from .repository import check_for_updates
 from .engine_tools import reset_retriever
 from .fetch import fetch
+from .scripts import reload_scripts
 
 __all__ = [
     'check_for_updates',
     'datasets',
     'dataset_names',
     'download',
+    'reload_scripts',
     'reset_retriever',
     'install_csv',
     'install_mysql',

--- a/retriever/lib/repository.py
+++ b/retriever/lib/repository.py
@@ -25,7 +25,7 @@ def _download_from_repository(filepath, newpath, repo=REPOSITORY):
         raise
 
 
-def check_for_updates(quiet=False):
+def check_for_updates():
     """Check for updates to datasets.
 
     This updates the HOME_DIR scripts directory with the latest script versions
@@ -42,6 +42,7 @@ def check_for_updates(quiet=False):
 
         # create script directory if not available
         if not os.path.isdir(SCRIPT_WRITE_PATH):
+            print('No scripts are currently available. Creating scripts folder...')
             os.makedirs(SCRIPT_WRITE_PATH)
 
         for script in tqdm(scripts, unit='files', desc='Downloading scripts'):

--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -14,8 +14,9 @@ from pkg_resources import parse_version
 
 from retriever.lib.defaults import SCRIPT_SEARCH_PATHS, VERSION, ENCODING, SCRIPT_WRITE_PATH
 from retriever.lib.load_json import read_json
+from retriever.lib.repository import check_for_updates
 
-global_script_list = {}
+global_script_list = None
 
 
 def check_retriever_minimum_version(module):
@@ -84,6 +85,8 @@ def reload_scripts():
                     sys.stderr.write("Failed to load script: {} ({})\n"
                                      "Exception: {} \n"
                                      .format(script_name, search_path, str(e)))
+    if global_script_list:
+        global_script_list.set_scripts(modules)
     return modules
 
 
@@ -170,6 +173,9 @@ class StoredScripts:
 
     def get_scripts(self):
         return self._shared_scripts
+
+    def set_scripts(self, script_list):
+        self._shared_scripts = script_list
 
 
 global_script_list = StoredScripts()

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ try:
     from retriever.compile import compile
     from retriever.lib.repository import check_for_updates
 
-    check_for_updates(False)
+    check_for_updates()
     compile()
 except:
     pass


### PR DESCRIPTION
I think this should fix the problems we've been having with ls after the retriever reset. 

Basically what was happening was the singleton class was getting created before doing a check for update which actually downloads everything. 

In this new format, we move the initial check for update logic into the singleton class instantiation. 

This is introduced in relation to #1229 