### PR TITLE
Add path argument for altering install directories

### DIFF
--- a/retriever/engines/csvengine.py
+++ b/retriever/engines/csvengine.py
@@ -26,7 +26,10 @@ class engine(Engine):
     required_opts = [
         ("table_name",
          "Format of table name",
-         os.path.join(DATA_DIR, "{db}_{table}.csv")),
+         "{db}_{table}.csv"),
+        ("data_dir",
+         "Install directory",
+         DATA_DIR),
     ]
     table_names = []
 
@@ -37,7 +40,7 @@ class engine(Engine):
     def create_table(self):
         """Create the table by creating an empty csv file"""
         self.auto_column_number = 1
-        self.file = open_fw(self.table_name())
+        self.file = open_fw(os.path.join(self.opts["data_dir"], self.table_name()))
         self.output_file = open_csvw(self.file)
         column_list = self.table.get_insert_columns(join=False, create=True)
         self.output_file.writerow([u'{}'.format(val) for val in column_list])
@@ -97,7 +100,9 @@ class engine(Engine):
     def table_exists(self, dbname, tablename):
         """Check to see if the data file currently exists"""
         tablename = self.table_name(name=tablename, dbname=dbname)
-        return os.path.exists(tablename)
+        tabledir = self.opts["data_dir"]
+        table_name = os.path.join(tabledir, tablename)
+        return os.path.exists(table_name)
 
     def to_csv(self, sort=True):
         """Export sorted version of CSV file"""

--- a/retriever/engines/jsonengine.py
+++ b/retriever/engines/jsonengine.py
@@ -30,7 +30,10 @@ class engine(Engine):
     required_opts = [
         ("table_name",
          "Format of table name",
-         os.path.join(DATA_DIR, "{db}_{table}.json")),
+         "{db}_{table}.json"),
+        ("data_dir",
+         "Install directory",
+         DATA_DIR),
     ]
     table_names = []
 
@@ -40,7 +43,7 @@ class engine(Engine):
 
     def create_table(self):
         """Create the table by creating an empty json file"""
-        self.output_file = open_fw(self.table_name())
+        self.output_file = open_fw(os.path.join(self.opts["data_dir"], self.table_name()))
         self.output_file.write("[")
         self.table_names.append((self.output_file, self.table_name()))
         self.auto_column_number = 1
@@ -115,7 +118,9 @@ class engine(Engine):
     def table_exists(self, dbname, tablename):
         """Check to see if the data file currently exists"""
         tablename = self.table_name(name=tablename, dbname=dbname)
-        return os.path.exists(tablename)
+        tabledir = self.opts["data_dir"]
+        table_name = os.path.join(tabledir, tablename)
+        return os.path.exists(table_name)
 
     def to_csv(self, sort=True, path=None):
         """Export table from json engine to CSV file"""

--- a/retriever/engines/msaccess.py
+++ b/retriever/engines/msaccess.py
@@ -27,11 +27,14 @@ class engine(Engine):
     insert_limit = 1000
     required_opts = [("file",
                       "Enter the filename of your Access database",
-                      os.path.join(DATA_DIR, "access.mdb"),
+                      "access.mdb",
                       "Access databases (*.mdb, *.accdb)|*.mdb;*.accdb"),
                      ("table_name",
                       "Format of table name",
                       "[{db} {table}]"),
+                     ("data_dir",
+                      "Install directory",
+                      DATA_DIR),
                      ]
     placeholder = "?"
 
@@ -144,8 +147,12 @@ IN "''' + filepath + '''" "Text;FMT=''' + fmt + ''';HDR=''' + hdr + ''';"'''
         import pypyodbc as dbapi
 
         self.get_input()
-        if not os.path.exists(self.opts['file']) and self.opts['file'].endswith('.mdb'):
-            dbapi.win_create_mdb(self.opts['file'])
+        file_name = self.opts["file"]
+        file_dir = self.opts["data_dir"]
+        ms_file = os.path.join(file_dir, file_name)
+
+        if not os.path.exists(ms_file) and ms_file.endswith('.mdb'):
+            dbapi.win_create_mdb(ms_file)
         connection_string = ("DRIVER={Microsoft Access Driver (*.mdb, *.accdb)};DBQ=" +
-                             os.path.abspath(self.opts["file"]).replace("/", "//") + ";")
+                             os.path.abspath(ms_file).replace("/", "//") + ";")
         return dbapi.connect(connection_string, autocommit=False)

--- a/retriever/engines/sqlite.py
+++ b/retriever/engines/sqlite.py
@@ -24,11 +24,13 @@ class engine(Engine):
     insert_limit = 1000
     required_opts = [("file",
                       "Enter the filename of your SQLite database",
-                      os.path.join(DATA_DIR, "sqlite.db"),
-                      ""),
+                      "sqlite.db"),
                      ("table_name",
                       "Format of table name",
                       "{db}_{table}"),
+                     ("data_dir",
+                      "Install directory",
+                      DATA_DIR),
                      ]
 
     def create_db(self):
@@ -106,4 +108,8 @@ class engine(Engine):
         import sqlite3 as dbapi
 
         self.get_input()
-        return dbapi.connect(self.opts["file"])
+        file = self.opts["file"]
+        db_file = self.opts["data_dir"]
+        full_path = os.path.join(db_file, file)
+
+        return dbapi.connect(os.path.normpath(full_path))

--- a/retriever/engines/xmlengine.py
+++ b/retriever/engines/xmlengine.py
@@ -26,7 +26,10 @@ class engine(Engine):
     required_opts = [
         ("table_name",
          "Format of table name",
-         os.path.join(DATA_DIR, "{db}_{table}.xml")),
+         "{db}_{table}.xml"),
+        ("data_dir",
+         "Install directory",
+         DATA_DIR),
     ]
     table_names = []
 
@@ -36,7 +39,7 @@ class engine(Engine):
 
     def create_table(self):
         """Create the table by creating an empty XML file."""
-        self.output_file = open_fw(self.table_name())
+        self.output_file = open_fw(os.path.join(self.opts["data_dir"], self.table_name()))
         self.output_file.write(u'<?xml version="1.0" encoding="UTF-8"?>')
         self.output_file.write(u'\n<root>')
         self.table_names.append((self.output_file, self.table_name()))

--- a/retriever/lib/engine.py
+++ b/retriever/lib/engine.py
@@ -24,7 +24,7 @@ from math import ceil
 from tqdm import tqdm
 from retriever.lib.tools import open_fr, open_fw, open_csvw, walk_relative_path
 from setuptools import archive_util
-from retriever.lib.defaults import DATA_SEARCH_PATHS, DATA_WRITE_PATH, ENCODING
+from retriever.lib.defaults import DATA_DIR, DATA_SEARCH_PATHS, DATA_WRITE_PATH, ENCODING
 from retriever.lib.cleanup import no_cleanup
 from retriever.lib.warning import Warning
 from urllib.request import urlretrieve
@@ -727,6 +727,11 @@ class Engine(object):
                     self.opts[opt[0]] = input(prompt)
             if self.opts[opt[0]] in ["", "default"]:
                 self.opts[opt[0]] = opt[2]
+        if 'data_dir' in self.opts:
+            if self.opts['data_dir'] != DATA_DIR:
+                if not os.path.exists(self.opts['data_dir']):
+                    os.makedirs(self.opts['data_dir'])
+
 
     def insert_data_from_archive(self, url, filenames):
         """Insert data from files located in an online archive. This function

--- a/retriever/lib/fetch.py
+++ b/retriever/lib/fetch.py
@@ -4,12 +4,12 @@ from retriever.lib.defaults import DATA_DIR
 from retriever.lib.install import install_sqlite
 
 
-def fetch(dataset, file=os.path.join(DATA_DIR, 'sqlite.db'), table_name='{db}_{table}'):
+def fetch(dataset, file='sqlite.db', table_name='{db}_{table}', data_dir=DATA_DIR):
     """Import a dataset into pandas data frames"""
     res_engine = install_sqlite(dataset, file=file, table_name=table_name)
     db_table_names = [name
                       for name, _ in res_engine.script_table_registry[dataset]]
     sqlite = engine()
-    sqlite.opts = {"file": file, "table_name": table_name}
+    sqlite.opts = {"file": file, "table_name": table_name, "data_dir": data_dir}
     df = sqlite.fetch_tables(dataset, db_table_names)
     return df

--- a/retriever/lib/install.py
+++ b/retriever/lib/install.py
@@ -37,14 +37,15 @@ def _install(args, use_cache, debug):
 
 
 def install_csv(dataset,
-                table_name=os.path.join(DATA_DIR, '{db}_{table}.csv'),
-                debug=False, use_cache=True):
+                table_name='{db}_{table}.csv',
+                data_dir=DATA_DIR, debug=False, use_cache=True):
     """Install datasets into csv."""
     args = {
         'command': 'install',
         'dataset': dataset,
         'engine': 'csv',
-        'table_name': table_name
+        'table_name': table_name,
+        'data_dir': data_dir
     }
     return _install(args, use_cache, debug)
 
@@ -88,8 +89,9 @@ def install_postgres(dataset, user='postgres', password='',
     return _install(args, use_cache, debug)
 
 
-def install_sqlite(dataset, file=os.path.join(DATA_DIR, 'sqlite.db'),
+def install_sqlite(dataset, file='sqlite.db',
                    table_name='{db}_{table}',
+                   data_dir=DATA_DIR,
                    debug=False, use_cache=True):
     """Install datasets into sqlite."""
     args = {
@@ -97,13 +99,15 @@ def install_sqlite(dataset, file=os.path.join(DATA_DIR, 'sqlite.db'),
         'dataset': dataset,
         'engine': 'sqlite',
         'file': file,
-        'table_name': table_name
+        'table_name': table_name,
+        'data_dir': data_dir
     }
     return _install(args, use_cache, debug)
 
 
-def install_msaccess(dataset, file=os.path.join(DATA_DIR, 'access.mdb'),
+def install_msaccess(dataset, file='access.mdb',
                      table_name='[{db} {table}]',
+                     data_dir=DATA_DIR,
                      debug=False, use_cache=True):
     """Install datasets into msaccess."""
     args = {
@@ -111,32 +115,35 @@ def install_msaccess(dataset, file=os.path.join(DATA_DIR, 'access.mdb'),
         'dataset': dataset,
         'engine': 'msaccess',
         'file': file,
-        'table_name': table_name
+        'table_name': table_name,
+        'data_dir': data_dir
     }
     return _install(args, use_cache, debug)
 
 
 def install_json(dataset,
-                 table_name=os.path.join(DATA_DIR, '{db}_{table}.json'),
-                 debug=False, use_cache=True):
+                 table_name='{db}_{table}.json',
+                 data_dir=DATA_DIR, debug=False, use_cache=True):
     """Install datasets into json."""
     args = {
         'command': 'install',
         'dataset': dataset,
         'engine': 'json',
-        'table_name': table_name
+        'table_name': table_name,
+        'data_dir': data_dir
     }
     return _install(args, use_cache, debug)
 
 
 def install_xml(dataset,
-                table_name=os.path.join(DATA_DIR, '{db}_{table}.xml'),
-                debug=False, use_cache=True):
+                table_name='{db}_{table}.xml',
+                data_dir=DATA_DIR, debug=False, use_cache=True):
     """Install datasets into xml."""
     args = {
         'command': 'install',
         'dataset': dataset,
         'engine': 'xml',
-        'table_name': table_name
+        'table_name': table_name,
+        'data_dir': data_dir
     }
     return _install(args, use_cache, debug)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from imp import reload
 
-from retriever.lib.defaults import ENCODING
+from retriever.lib.defaults import ENCODING, DATA_DIR
 
 encoding = ENCODING.lower()
 
@@ -474,17 +474,18 @@ def get_output_as_csv(dataset, engines, tmpdir, db):
 
 @pytest.mark.parametrize("dataset, expected", test_parameters)
 def test_csv_integration(dataset, expected, tmpdir):
-    csv_engine.opts = {'engine': 'csv', 'table_name': '{db}_{table}'}
+    csv_engine.opts = {'engine': 'csv', 'table_name': '{db}_{table}', 'data_dir': DATA_DIR}
     assert get_output_as_csv(dataset, csv_engine, tmpdir, db=dataset["name"]) == expected
 
 
 @pytest.mark.parametrize("dataset, expected", test_parameters)
 def test_sqlite_integration(dataset, expected, tmpdir):
-    dbfile = os.path.normpath(os.path.join(os.getcwd(), 'testdb.sqlite'))
+    dbfile = 'testdb.sqlite'
     sqlite_engine.opts = {
         'engine': 'sqlite',
         'file': dbfile,
-        'table_name': '{db}_{table}'}
+        'table_name': '{db}_{table}',
+        'data_dir': DATA_DIR}
     subprocess.call(['rm', '-r', 'testdb.sqlite'])
     assert get_output_as_csv(dataset, sqlite_engine, tmpdir, dataset["name"]) == expected
 
@@ -492,14 +493,14 @@ def test_sqlite_integration(dataset, expected, tmpdir):
 @pytest.mark.parametrize("dataset, expected", xml_test_parameters)
 def test_xmlengine_integration(dataset, expected, tmpdir):
     """Check for xmlenginee regression."""
-    xml_engine.opts = {'engine': 'xml', 'table_name': '{db}_{table}'}
+    xml_engine.opts = {'engine': 'xml', 'table_name': '{db}_{table}', 'data_dir': DATA_DIR}
     assert get_output_as_csv(dataset, xml_engine, tmpdir, db=dataset["name"]) == expected
 
 
 @pytest.mark.parametrize("dataset, expected", test_parameters)
 def test_jsonengine_integration(dataset, expected, tmpdir):
     """Check for jsonenginee regression."""
-    json_engine.opts = {'engine': 'json', 'table_name': '{db}_{table}'}
+    json_engine.opts = {'engine': 'json', 'table_name': '{db}_{table}', 'data_dir': DATA_DIR}
     assert get_output_as_csv(dataset, json_engine, tmpdir, db=dataset["name"]) == expected
 
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -17,7 +17,7 @@ from retriever import install_mysql
 from retriever import install_postgres
 from retriever import install_sqlite
 from retriever import install_xml
-from retriever.lib.defaults import ENCODING
+from retriever.lib.defaults import ENCODING, DATA_DIR
 from retriever.lib.load_json import read_json
 
 encoding = ENCODING.lower()
@@ -137,12 +137,17 @@ def get_csv_md5(dataset, engine, tmpdir, install_function, config):
 def test_sqlite_regression(dataset, expected, tmpdir):
     """Check for sqlite regression."""
     subprocess.call(['rm', '-r', 'testdb.sqlite'])
-    dbfile = os.path.normpath(os.path.join(os.getcwd(), 'testdb.sqlite'))
+    dbfile = 'testdb.sqlite'
+    if os.path.exists(dbfile):
+        subprocess.call(['rm', '-r', dbfile])
+    # SQlite should install datasets into a different folder from where .csv are dumped
+    # This avoids having the `testdb.sqlite` being considered for md5 sum
     sqlite_engine.opts = {
         'engine': 'sqlite',
         'file': dbfile,
-        'table_name': '{db}_{table}'}
-    interface_opts = {'file': dbfile}
+        'table_name': '{db}_{table}',
+        'data_dir': DATA_DIR}
+    interface_opts = {'file': dbfile, 'data_dir': retriever_root_dir}
     assert get_csv_md5(dataset, sqlite_engine, tmpdir, install_sqlite, interface_opts) == expected
 
 
@@ -191,7 +196,8 @@ def test_xmlengine_regression(dataset, expected, tmpdir):
     """Check for xmlenginee regression."""
     xml_engine.opts = {
         'engine': 'xml',
-        'table_name': '{db}_output_{table}.xml'}
+        'table_name': '{db}_output_{table}.xml',
+        'data_dir': DATA_DIR}
     interface_opts = {'table_name': '{db}_output_{table}.xml'}
     assert get_csv_md5(dataset, xml_engine, tmpdir, install_xml, interface_opts) == expected
 
@@ -201,7 +207,8 @@ def test_jsonengine_regression(dataset, expected, tmpdir):
     """Check for jsonenginee regression."""
     json_engine.opts = {
         'engine': 'json',
-        'table_name': '{db}_output_{table}.json'}
+        'table_name': '{db}_output_{table}.json',
+        'data_dir': DATA_DIR}
     interface_opts = {'table_name': '{db}_output_{table}.json'}
     assert get_csv_md5(dataset, json_engine, tmpdir, install_json, interface_opts) == expected
 
@@ -211,7 +218,8 @@ def test_csv_regression(dataset, expected, tmpdir):
     """Check csv regression."""
     csv_engine.opts = {
         'engine': 'csv',
-        'table_name': '{db}_output_{table}.csv'}
+        'table_name': '{db}_output_{table}.csv',
+        'data_dir': DATA_DIR}
     interface_opts = {'table_name': '{db}_output_{table}.csv'}
     assert get_csv_md5(dataset, csv_engine, tmpdir, install_csv, interface_opts) == expected
 


### PR DESCRIPTION
This pull request aims to fix: #1137. It adds an optional `data_dir` argument to provide a more straight forward custom directory for installation of datasets.