### PR TITLE
Create absent directories when installing to flat files

### DIFF
--- a/retriever/__main__.py
+++ b/retriever/__main__.py
@@ -196,6 +196,8 @@ def main():
             for dataset in scripts:
                 print("=> Installing", dataset.name)
                 try:
+                    if not os.path.exists(args.data_dir):
+                        os.makedirs(args.data_dir)
                     dataset.download(engine, debug=debug)
                     dataset.engine.final_cleanup()
                 except KeyboardInterrupt:


### PR DESCRIPTION
This PR fixes #1136 . It will create directory on the fly if it does not exists.