### PR TITLE
edit_json cannot dump to file correctly

### DIFF
--- a/retriever/lib/datapackage.py
+++ b/retriever/lib/datapackage.py
@@ -247,8 +247,8 @@ def create_json():
     file_name = contents['name'] + ".json"
     file_name = file_name.replace('-', '_')
     with open(os.path.join(HOME_DIR, 'scripts', file_name), 'w') as output_file:
-        json_str = json.dumps(contents, output_file, sort_keys=True, indent=4,
-                              separators=(',', ': '))
+        json_str = str(json.dump(contents, output_file, sort_keys=True, indent=4,
+                              separators=(',', ': ')))
         output_file.write(json_str + '\n')
         print("\nScript written to " + file_name)
         output_file.close()
@@ -426,8 +426,8 @@ def edit_json(json_file):
     file_name = contents['name'] + ".json"
     file_name = file_name.replace('-', '_')
     with open(os.path.join(HOME_DIR, 'scripts', file_name), 'w') as output_file:
-        json_str = json.dumps(contents, output_file, sort_keys=True, indent=4,
-                              separators=(',', ': '))
+        json_str = str(json.dump(contents, output_file, sort_keys=True, indent=4,
+                              separators=(',', ': ')))
         output_file.write(json_str + '\n')
         print("\nScript written to " +
               os.path.join(HOME_DIR, 'scripts', file_name))


### PR DESCRIPTION
json.dumps takes only 1 argument since Python 3.6 so it's replaced by json.dump
Fixes issue #1240 