### PR TITLE
Setting up automating infrastructure for the creation of some clean scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1038272.svg)](https://doi.org/10.5281/zenodo.1038272)
 [![JOSS Publication](http://joss.theoj.org/papers/10.21105/joss.00451/status.svg)](https://doi.org/10.21105/joss.00451)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/retriever/badges/version.svg)](https://anaconda.org/conda-forge/retriever)
+[![Version](https://img.shields.io/pypi/v/retriever.svg)](https://pypi.python.org/pypi/retriever)
+
 
 Finding data is one thing. Getting it ready for analysis is another. Acquiring,
 cleaning, standardizing and importing publicly available data is time consuming

--- a/retriever/__main__.py
+++ b/retriever/__main__.py
@@ -17,6 +17,7 @@ from retriever.lib.engine_tools import name_matches, reset_retriever
 from retriever.lib.get_opts import parser
 from retriever.lib.repository import check_for_updates
 from retriever.lib.scripts import SCRIPT_LIST, reload_scripts, get_script
+from retriever.lib.create_scripts import create_package
 
 
 def main():
@@ -103,6 +104,13 @@ def main():
             # edit existing JSON script
             json_file = get_script_filename(args.dataset.lower())
             edit_json(json_file)
+            return
+
+        elif args.command == 'autocreate':
+            if sum([args.f, args.d]) == 1:
+                create_package(args.path, args.dt, args.f, args.d, args.o, args.skip_lines)
+            else:
+                print('Please use one and only one of the flags -f -d')
             return
 
         elif args.command == 'delete_json':

--- a/retriever/__main__.py
+++ b/retriever/__main__.py
@@ -108,7 +108,8 @@ def main():
 
         elif args.command == 'autocreate':
             if sum([args.f, args.d]) == 1:
-                create_package(args.path, args.dt, args.f, args.d, args.o, args.skip_lines)
+                file_flag = True if args.f else False
+                create_package(args.path, args.dt, file_flag, args.o, args.skip_lines)
             else:
                 print('Please use one and only one of the flags -f -d')
             return

--- a/retriever/lib/__init__.py
+++ b/retriever/lib/__init__.py
@@ -1,5 +1,6 @@
 """retriever.lib contains the core Data Retriever modules."""
 
+from .create_scripts import create_package
 from .datasets import datasets
 from .datasets import dataset_names
 from .download import download
@@ -17,6 +18,7 @@ from .scripts import reload_scripts
 
 __all__ = [
     'check_for_updates',
+    'create_package',
     'datasets',
     'dataset_names',
     'download',

--- a/retriever/lib/create_scripts.py
+++ b/retriever/lib/create_scripts.py
@@ -1,0 +1,236 @@
+#! /usr/bin/env python
+import collections
+import os
+import json
+import io
+try:
+    from osgeo import ogr
+except ImportError:
+    pass
+from retriever.lib.engine import Engine
+from retriever.lib.models import Table
+from retriever.lib.datapackage import clean_input
+from retriever.lib.tools import open_fw
+
+def get_directory(path):
+    return_path = path
+    if not os.path.isdir(return_path):
+        return_path = os.path.dirname(path)
+    return return_path
+
+def create_package(path, datatype, fileFlag, dirFlag, write_out_flag_path, skip_lines):
+    path = os.path.expanduser(os.path.normpath(path))
+    if not os.path.exists(path):
+        print('Please enter a valid path.')
+
+    if write_out_flag_path is not None and write_out_flag_path == '':
+        write_out_flag_path = os.path.join(get_directory(path), 'scripts')
+    skip_lines = skip_lines[0] if skip_lines else 1
+
+    if datatype.lower() == 'vector':
+        create_vector_datapackage(path)
+    elif datatype.lower() == 'raster':
+        pass
+    elif dirFlag:
+        process_dirs(path, write_out_flag_path, skip_lines)
+    elif fileFlag:
+        process_singles(path, write_out_flag_path, skip_lines)
+
+
+def create_resources(file, skip_lines):
+    engine = Engine()
+    table = engine.auto_create_table(
+        Table(str(file), header_rows=skip_lines), filename=file, make=False)
+    cleanTable = table.__dict__
+    resourceDict = {}
+    pathToTable = os.path.basename(cleanTable['name'])
+    resourceDict['name'] = os.path.splitext(pathToTable)[0]
+    resourceDict['schema'] = {}
+    resourceDict['dialect'] = {}
+    resourceDict['schema']['fields'] = []
+    for cname, ctuple in cleanTable['columns']:
+        resourceDict['schema']['fields'].append(
+            {'name': cname, 'type': ctuple[0]})
+    resourceDict['url'] = "FILL"
+    return resourceDict
+
+
+def create_script_dict(allpacks, path, file_n, skip_lines):
+    allpacks["name"] = "FILL"
+    allpacks["title"] = "FILL"
+    allpacks["description"] = "FILL"
+    allpacks["citation"] = "FILL"
+    allpacks["licenses"] = [{"name": "FILL"}]
+    allpacks["keywords"] = []
+    allpacks["homepage"] = "FILL"
+    allpacks["version"] = "1.0.0"
+    try:
+        resources = create_resources(
+            os.path.join(path, file_n), skip_lines)
+    except:
+        print('Skipped file: ' + file_n)
+        return
+    allpacks.setdefault('resources', []).append(resources)
+    allpacks["retriever"] = "True",
+    allpacks["retriever_minimum_version"] = "2.1.0"
+
+    return allpacks
+
+
+def write_out_scripts(scriptDict, path, write_out_flag_path):
+    file_name = os.path.basename(path).split('.')[0] + '.json'
+    path_dir = get_directory(os.path.expanduser(path))
+    if write_out_flag_path is not None:
+        path_dir = os.path.expanduser(write_out_flag_path)
+        if not os.path.exists(path_dir):
+            os.mkdir(path_dir)
+    write_path = os.path.join(path_dir, file_name)
+
+    if not (scriptDict and 'resources' in scriptDict):
+        print(write_path + ' creation skipped because resources were empty.')
+        return
+    if os.path.exists(write_path):
+        choice = clean_input(write_path + ' already exists. Overwrite the script? [y/n]')
+        if choice == 'n':
+            print(write_path + ' creation skipped.')
+            return
+    try:
+        with open_fw(write_path) as outputPath:
+            sortedDict = collections.OrderedDict(sorted(scriptDict.items()))
+            jsonstr = json.dumps(sortedDict, sort_keys=True, indent=4)
+            outputPath.write(jsonstr)
+            print('Successfully wrote scripts to ' + os.path.abspath(write_path))
+            outputPath.close()
+    except Exception as e:
+        print(write_path + ' could not be created. {}'.format(e.message))
+
+
+def process_dirs(sub_dirs_path, write_out_flag_path, skip_lines):
+    for path, subdirs, files in os.walk(sub_dirs_path):
+        allpacks = collections.OrderedDict()
+        for file_n in files:
+            if file_n:
+                try_create_dict =  create_script_dict(allpacks, path, file_n, skip_lines)
+                if try_create_dict:
+                    allpacks = try_create_dict
+        write_out_scripts(allpacks, path, write_out_flag_path)
+
+
+def process_singles(single_files_path, write_out_flag_path, skip_lines):
+    if os.path.isdir(single_files_path):
+        for path, subdirs, files in os.walk(single_files_path):
+            for file_n in files:
+                allpacks = collections.OrderedDict()
+                if file_n:
+                    allpacks = create_script_dict(allpacks, path, file_n, skip_lines)
+                    filepath = os.path.join(path, file_n)
+                    write_out_scripts(allpacks, filepath, write_out_flag_path)
+    else:
+        directory = os.path.dirname(single_files_path)
+        file_name = os.path.basename(single_files_path)
+        allpacks = collections.OrderedDict()
+        allpacks = create_script_dict(allpacks, directory, file_name, skip_lines)
+        write_out_scripts(allpacks, single_files_path, write_out_flag_path)
+
+
+
+def get_projection(source, driver_name ='ESRI Shapefile'):
+    """Get projection from Layer"""
+
+    data_src = get_source(source, driver_name)
+    layer = data_src.GetLayer()
+    spatial_ref = layer.GetSpatialRef()
+    return spatial_ref.ExportToWkt()
+
+    spatial_ref = layer.GetSpatialRef()
+    ref = spatial_ref.ExportToWkt()
+
+
+def get_source(source, driver_name ='ESRI Shapefile'):
+    """Open a data source
+    if source is of class osgeo.ogr.DataSource read data source else
+    consider it a path and open the path return a data source
+    """
+    if not isinstance(source, ogr.DataSource):
+        try:
+            driver = ogr.GetDriverByName(driver_name)
+            source = driver.Open(source, 0)
+            if source is None:
+                print('Could not open %s' % (source))
+                exit()
+
+        except:
+            raise IOError("Data source cannot be opened")
+    return source
+
+
+def create_vector_datapackage(file_path, driver_name='ESRI Shapefile' ):
+    """Create a data package from a vector data source
+    the root dir of the vector file becomes the package name
+    """
+    allpacks = collections.OrderedDict()
+    for path, subdirs, files in os.walk(file_path):
+        for file_n in files:
+            if file_n.endswith(".shp"):
+                path_to_dir = os.path.abspath(path)
+                dir_name = os.path.basename(path_to_dir)
+
+                file_path_source = os.path.join(path_to_dir, file_n)
+                source = os.path.normpath(file_path_source)
+
+                layer_scr = get_source(source, driver_name)
+                daLayer = layer_scr.GetLayer()
+
+                allpacks[dir_name] = collections.OrderedDict()
+                # spactial ref
+                sp_ref = daLayer.GetSpatialRef()
+                spatial_ref = "{}".format(str(sp_ref.ExportToWkt()))
+
+                # Json data package dictionary
+                allpacks[dir_name]["name"] = daLayer.GetName()
+                allpacks[dir_name]["title"] = "The {} dataset".format(daLayer.GetName())
+                allpacks[dir_name]["description"] = daLayer.GetDescription()
+                allpacks[dir_name]["format"] = "vector" # like  https://specs.frictionlessdata.io/data-resource/ in format: 'csv', 'xls', 'json' here we clasify by type vector or raster
+                allpacks[dir_name]["spatial_ref"] = spatial_ref
+                allpacks[dir_name]["citation"] = "weaver Pending clarification"
+                allpacks[dir_name]["license"] = "Licence for dataset Pending clarification"
+                allpacks[dir_name]["driver_name"] ='ESRI Shapefile'
+                allpacks[dir_name]["extent"] = OrderedDict(zip(["xMin", "xMax", "yMin", "yMax"], daLayer.GetExtent()))
+                allpacks[dir_name]["keywords"] = ["test", "data science", "spatial-data"]
+                allpacks[dir_name]["url"] = "FILL"
+                allpacks[dir_name]["version"] = "1.0.0"
+                allpacks[dir_name]["resources"] = []
+                allpacks[dir_name]["retriever"] = "True",
+                allpacks[dir_name]["retriever_minimum_version"] = "2.1.0",
+
+                layer = collections.OrderedDict()
+                layer["name"] = daLayer.GetName()
+                layer["url"] = str(daLayer.GetName())+ "path_to_be_filled"
+                layer["geom_type"] = ogr.GeometryTypeToName(daLayer.GetLayerDefn().GetGeomType())
+                layer['schema'] = {}
+                layer['schema']["fields"] = []
+                layerDefinition = daLayer.GetLayerDefn()
+                for i in range(layerDefinition.GetFieldCount()):
+                    col_obj = collections.OrderedDict()
+                    col_obj["name"] = layerDefinition.GetFieldDefn(i).GetName()
+                    col_obj["precision"] = layerDefinition.GetFieldDefn(i).GetPrecision()
+                    col_obj["type"] = layerDefinition.GetFieldDefn(i).GetTypeName()
+                    col_obj["size"] = layerDefinition.GetFieldDefn(i).GetWidth()
+                    layer["schema"]["fields"].append(col_obj)
+                allpacks[dir_name]["resources"].append(layer)
+
+    for path, subdirs, files in os.walk(file_path):
+        for file_n in files:
+            if file_n.endswith(".shp"):
+                path_to_dir = os.path.abspath(path)
+                dir_name = os.path.basename(path_to_dir)
+                filenamejson = file_n[:-4].replace("-", "_").replace(".", "") + ".json"
+                # file_path_source = os.path.join(r"C:\Users\Henry\Documents\GitHub\Geodata\tutotial_data\Data_2\raster_packages", filenamejson)
+                file_path_source = os.path.join('.', filenamejson)
+                with open_fw(file_path_source) as output_spec_datapack:
+                    json_str = json.dumps(allpacks[dir_name], sort_keys=True, indent=4,
+                                          separators=(',', ': '))
+
+                    output_spec_datapack.write(json_str + '\n')
+
+                    output_spec_datapack.close()

--- a/retriever/lib/create_scripts.py
+++ b/retriever/lib/create_scripts.py
@@ -1,61 +1,90 @@
 #! /usr/bin/env python
+"""Module to create scripts"""
 import collections
 import os
 import json
-import io
-try:
-    from osgeo import ogr
-except ImportError:
-    pass
+
 from retriever.lib.engine import Engine
 from retriever.lib.models import Table
 from retriever.lib.datapackage import clean_input
 from retriever.lib.tools import open_fw
 
+
 def get_directory(path):
-    return_path = path
-    if not os.path.isdir(return_path):
-        return_path = os.path.dirname(path)
-    return return_path
+    """Returns absolute directory path for a path."""
+    path = os.path.expanduser(path)
+    path = os.path.normpath(path)
+    path = os.path.abspath(path)
+    if not os.path.isdir(path):
+        path = os.path.dirname(path)
+    return path
 
-def create_package(path, datatype, fileFlag, dirFlag, write_out_flag_path, skip_lines):
+
+def create_package(path, data_type, file_flag, out_path, skip_lines=None):
+    """Creates package for a path
+
+    path: string path to files to be processed
+    data_type: string data type of the files to be processed
+    file_flag: boolean for whether the files are processed as files or directories
+    out_path: string path to write scripts out to
+    skip_lines: int number of lines to skip
+    """
     path = os.path.expanduser(os.path.normpath(path))
-    if not os.path.exists(path):
-        print('Please enter a valid path.')
-
-    if write_out_flag_path is not None and write_out_flag_path == '':
-        write_out_flag_path = os.path.join(get_directory(path), 'scripts')
     skip_lines = skip_lines[0] if skip_lines else 1
+    if not os.path.exists(path):
+        print("Please enter a valid path.")
+        return
 
-    if datatype.lower() == 'vector':
-        create_vector_datapackage(path)
-    elif datatype.lower() == 'raster':
-        pass
-    elif dirFlag:
-        process_dirs(path, write_out_flag_path, skip_lines)
-    elif fileFlag:
-        process_singles(path, write_out_flag_path, skip_lines)
+    if not out_path and out_path == "":
+        out_path = os.path.join(get_directory(path), "scripts")
+
+    if data_type.lower() == "vector":
+        create_vector_datapackage()
+    elif data_type.lower() == "raster":
+        create_raster_datapackage()
+    elif data_type.lower() == "tabular":
+        create_tabular_datapackage(path, file_flag, out_path, skip_lines)
+
+
+def create_raster_datapackage():
+    """Creates raster package for a path"""
+    pass
+
+
+def create_tabular_datapackage(path, file_flag, out_path, skip_lines):
+    """Creates tabular package for a path"""
+    if file_flag:
+        process_singles(path, out_path, skip_lines)
+    else:
+        process_dirs(path, out_path, skip_lines)
+
+
+def create_vector_datapackage():
+    """Creates vector package for a path"""
+    pass
 
 
 def create_resources(file, skip_lines):
+    """Creates resources for the script or errors out if not possible"""
     engine = Engine()
     table = engine.auto_create_table(
-        Table(str(file), header_rows=skip_lines), filename=file, make=False)
-    cleanTable = table.__dict__
-    resourceDict = {}
-    pathToTable = os.path.basename(cleanTable['name'])
-    resourceDict['name'] = os.path.splitext(pathToTable)[0]
-    resourceDict['schema'] = {}
-    resourceDict['dialect'] = {}
-    resourceDict['schema']['fields'] = []
-    for cname, ctuple in cleanTable['columns']:
-        resourceDict['schema']['fields'].append(
-            {'name': cname, 'type': ctuple[0]})
-    resourceDict['url'] = "FILL"
-    return resourceDict
+        Table(str(file), header_rows=skip_lines), filename=file, make=False
+    )
+    clean_table = table.__dict__
+    resource_dict = {}
+    path_to_table = os.path.basename(clean_table["name"])
+    resource_dict["name"] = os.path.splitext(path_to_table)[0]
+    resource_dict["schema"] = {}
+    resource_dict["dialect"] = {}
+    resource_dict["schema"]["fields"] = []
+    for cname, ctuple in clean_table["columns"]:
+        resource_dict["schema"]["fields"].append({"name": cname, "type": ctuple[0]})
+    resource_dict["url"] = "FILL"
+    return resource_dict
 
 
-def create_script_dict(allpacks, path, file_n, skip_lines):
+def create_script_dict(allpacks, path, file, skip_lines):
+    """Create script dict or skips file if resources cannot be made"""
     allpacks["name"] = "FILL"
     allpacks["title"] = "FILL"
     allpacks["description"] = "FILL"
@@ -65,172 +94,87 @@ def create_script_dict(allpacks, path, file_n, skip_lines):
     allpacks["homepage"] = "FILL"
     allpacks["version"] = "1.0.0"
     try:
-        resources = create_resources(
-            os.path.join(path, file_n), skip_lines)
+        resources = create_resources(os.path.join(path, file), skip_lines)
     except:
-        print('Skipped file: ' + file_n)
+        print("Skipped file: " + file)
         return
-    allpacks.setdefault('resources', []).append(resources)
-    allpacks["retriever"] = "True",
+    allpacks.setdefault("resources", []).append(resources)
+    allpacks["retriever"] = ("True",)
     allpacks["retriever_minimum_version"] = "2.1.0"
 
     return allpacks
 
 
-def write_out_scripts(scriptDict, path, write_out_flag_path):
-    file_name = os.path.basename(path).split('.')[0] + '.json'
-    path_dir = get_directory(os.path.expanduser(path))
-    if write_out_flag_path is not None:
-        path_dir = os.path.expanduser(write_out_flag_path)
-        if not os.path.exists(path_dir):
-            os.mkdir(path_dir)
-    write_path = os.path.join(path_dir, file_name)
+def process_dirs(sub_dirs_path, out_path, skip_lines):
+    """Creates a script for each directory
 
-    if not (scriptDict and 'resources' in scriptDict):
-        print(write_path + ' creation skipped because resources were empty.')
-        return
-    if os.path.exists(write_path):
-        choice = clean_input(write_path + ' already exists. Overwrite the script? [y/n]')
-        if choice == 'n':
-            print(write_path + ' creation skipped.')
-            return
-    try:
-        with open_fw(write_path) as outputPath:
-            sortedDict = collections.OrderedDict(sorted(scriptDict.items()))
-            jsonstr = json.dumps(sortedDict, sort_keys=True, indent=4)
-            outputPath.write(jsonstr)
-            print('Successfully wrote scripts to ' + os.path.abspath(write_path))
-            outputPath.close()
-    except Exception as e:
-        print(write_path + ' could not be created. {}'.format(e.message))
-
-
-def process_dirs(sub_dirs_path, write_out_flag_path, skip_lines):
-    for path, subdirs, files in os.walk(sub_dirs_path):
+    If there are subdirectories in a directory, a script is created for each
+    subdirectory.
+    If there are no subdirectories in a directory, a script is created for the
+    directory with the resources being the files in the directory.
+    If there are subdirectories and files in a directory, a script is created
+    for each subdirectory, and a script is created for the main directory with
+    the resources being the files in the directory.
+    """
+    for path, _, files in os.walk(sub_dirs_path):
         allpacks = collections.OrderedDict()
         for file_n in files:
             if file_n:
-                try_create_dict =  create_script_dict(allpacks, path, file_n, skip_lines)
+                try_create_dict = create_script_dict(allpacks, path, file_n, skip_lines)
                 if try_create_dict:
                     allpacks = try_create_dict
-        write_out_scripts(allpacks, path, write_out_flag_path)
+        write_out_scripts(allpacks, path, out_path)
 
 
-def process_singles(single_files_path, write_out_flag_path, skip_lines):
+def process_singles(single_files_path, out_path, skip_lines):
+    """Creates a script for each file
+
+    If the filepath is a file, creates a single script for that file.
+    If the filepath is a directory, creates a single script for each file in the
+    directory.
+    """
     if os.path.isdir(single_files_path):
-        for path, subdirs, files in os.walk(single_files_path):
+        for path, _, files in os.walk(single_files_path):
             for file_n in files:
                 allpacks = collections.OrderedDict()
                 if file_n:
                     allpacks = create_script_dict(allpacks, path, file_n, skip_lines)
                     filepath = os.path.join(path, file_n)
-                    write_out_scripts(allpacks, filepath, write_out_flag_path)
+                    write_out_scripts(allpacks, filepath, out_path)
     else:
         directory = os.path.dirname(single_files_path)
         file_name = os.path.basename(single_files_path)
         allpacks = collections.OrderedDict()
         allpacks = create_script_dict(allpacks, directory, file_name, skip_lines)
-        write_out_scripts(allpacks, single_files_path, write_out_flag_path)
+        write_out_scripts(allpacks, single_files_path, out_path)
 
 
+def write_out_scripts(script_dict, path, out_path):
+    """Writes scripts out to a given path"""
+    file_name = os.path.basename(path).split(".")[0] + ".json"
+    path_dir = get_directory(os.path.expanduser(path))
+    if out_path is not None:
+        path_dir = os.path.expanduser(out_path)
+        if not os.path.exists(path_dir):
+            os.mkdir(path_dir)
+    write_path = os.path.join(path_dir, file_name)
 
-def get_projection(source, driver_name ='ESRI Shapefile'):
-    """Get projection from Layer"""
-
-    data_src = get_source(source, driver_name)
-    layer = data_src.GetLayer()
-    spatial_ref = layer.GetSpatialRef()
-    return spatial_ref.ExportToWkt()
-
-    spatial_ref = layer.GetSpatialRef()
-    ref = spatial_ref.ExportToWkt()
-
-
-def get_source(source, driver_name ='ESRI Shapefile'):
-    """Open a data source
-    if source is of class osgeo.ogr.DataSource read data source else
-    consider it a path and open the path return a data source
-    """
-    if not isinstance(source, ogr.DataSource):
-        try:
-            driver = ogr.GetDriverByName(driver_name)
-            source = driver.Open(source, 0)
-            if source is None:
-                print('Could not open %s' % (source))
-                exit()
-
-        except:
-            raise IOError("Data source cannot be opened")
-    return source
-
-
-def create_vector_datapackage(file_path, driver_name='ESRI Shapefile' ):
-    """Create a data package from a vector data source
-    the root dir of the vector file becomes the package name
-    """
-    allpacks = collections.OrderedDict()
-    for path, subdirs, files in os.walk(file_path):
-        for file_n in files:
-            if file_n.endswith(".shp"):
-                path_to_dir = os.path.abspath(path)
-                dir_name = os.path.basename(path_to_dir)
-
-                file_path_source = os.path.join(path_to_dir, file_n)
-                source = os.path.normpath(file_path_source)
-
-                layer_scr = get_source(source, driver_name)
-                daLayer = layer_scr.GetLayer()
-
-                allpacks[dir_name] = collections.OrderedDict()
-                # spactial ref
-                sp_ref = daLayer.GetSpatialRef()
-                spatial_ref = "{}".format(str(sp_ref.ExportToWkt()))
-
-                # Json data package dictionary
-                allpacks[dir_name]["name"] = daLayer.GetName()
-                allpacks[dir_name]["title"] = "The {} dataset".format(daLayer.GetName())
-                allpacks[dir_name]["description"] = daLayer.GetDescription()
-                allpacks[dir_name]["format"] = "vector" # like  https://specs.frictionlessdata.io/data-resource/ in format: 'csv', 'xls', 'json' here we clasify by type vector or raster
-                allpacks[dir_name]["spatial_ref"] = spatial_ref
-                allpacks[dir_name]["citation"] = "weaver Pending clarification"
-                allpacks[dir_name]["license"] = "Licence for dataset Pending clarification"
-                allpacks[dir_name]["driver_name"] ='ESRI Shapefile'
-                allpacks[dir_name]["extent"] = OrderedDict(zip(["xMin", "xMax", "yMin", "yMax"], daLayer.GetExtent()))
-                allpacks[dir_name]["keywords"] = ["test", "data science", "spatial-data"]
-                allpacks[dir_name]["url"] = "FILL"
-                allpacks[dir_name]["version"] = "1.0.0"
-                allpacks[dir_name]["resources"] = []
-                allpacks[dir_name]["retriever"] = "True",
-                allpacks[dir_name]["retriever_minimum_version"] = "2.1.0",
-
-                layer = collections.OrderedDict()
-                layer["name"] = daLayer.GetName()
-                layer["url"] = str(daLayer.GetName())+ "path_to_be_filled"
-                layer["geom_type"] = ogr.GeometryTypeToName(daLayer.GetLayerDefn().GetGeomType())
-                layer['schema'] = {}
-                layer['schema']["fields"] = []
-                layerDefinition = daLayer.GetLayerDefn()
-                for i in range(layerDefinition.GetFieldCount()):
-                    col_obj = collections.OrderedDict()
-                    col_obj["name"] = layerDefinition.GetFieldDefn(i).GetName()
-                    col_obj["precision"] = layerDefinition.GetFieldDefn(i).GetPrecision()
-                    col_obj["type"] = layerDefinition.GetFieldDefn(i).GetTypeName()
-                    col_obj["size"] = layerDefinition.GetFieldDefn(i).GetWidth()
-                    layer["schema"]["fields"].append(col_obj)
-                allpacks[dir_name]["resources"].append(layer)
-
-    for path, subdirs, files in os.walk(file_path):
-        for file_n in files:
-            if file_n.endswith(".shp"):
-                path_to_dir = os.path.abspath(path)
-                dir_name = os.path.basename(path_to_dir)
-                filenamejson = file_n[:-4].replace("-", "_").replace(".", "") + ".json"
-                # file_path_source = os.path.join(r"C:\Users\Henry\Documents\GitHub\Geodata\tutotial_data\Data_2\raster_packages", filenamejson)
-                file_path_source = os.path.join('.', filenamejson)
-                with open_fw(file_path_source) as output_spec_datapack:
-                    json_str = json.dumps(allpacks[dir_name], sort_keys=True, indent=4,
-                                          separators=(',', ': '))
-
-                    output_spec_datapack.write(json_str + '\n')
-
-                    output_spec_datapack.close()
+    if not (script_dict and "resources" in script_dict):
+        print(write_path + " creation skipped because resources were empty.")
+        return
+    if os.path.exists(write_path):
+        choice = clean_input(
+            write_path + " already exists. Overwrite the script? [y/n]"
+        )
+        if choice == "n":
+            print(write_path + " creation skipped.")
+            return
+    try:
+        with open_fw(write_path) as output_path:
+            sourted_dict = collections.OrderedDict(sorted(script_dict.items()))
+            jsonstr = json.dumps(sourted_dict, sort_keys=True, indent=4)
+            output_path.write(jsonstr)
+            print("Successfully wrote scripts to " + os.path.abspath(write_path))
+            output_path.close()
+    except Exception as e:
+        print(write_path + " could not be created. {}".format(e.message))

--- a/retriever/lib/engine.py
+++ b/retriever/lib/engine.py
@@ -203,7 +203,7 @@ class Engine(object):
                     name = []
                 yield (begin + name + [item])
 
-    def auto_create_table(self, table, url=None, filename=None, pk=None):
+    def auto_create_table(self, table, url=None, filename=None, pk=None, make=True):
         """Create table automatically by analyzing a data source and
         predicting column names, data types, delimiter, etc."""
         if url and not filename:
@@ -239,7 +239,8 @@ class Engine(object):
             self.table.columns = self.table.columns[:-1] + \
                                  [(self.table.ct_column, ("char", 50))] + \
                                  [self.table.columns[-1]]
-
+        if not make:
+            return self.table
         self.create_table()
 
     def auto_get_datatypes(self, pk, source, columns):
@@ -646,7 +647,7 @@ class Engine(object):
     def find_file(self, filename):
         """Check for an existing datafile."""
         for search_path in DATA_SEARCH_PATHS:
-            search_path = search_path.format(dataset=self.script.name)
+            search_path = search_path.format(dataset=self.script.name) if self.script else search_path
             file_path = os.path.normpath(os.path.join(search_path, filename))
             if file_exists(file_path):
                 return file_path

--- a/retriever/lib/get_opts.py
+++ b/retriever/lib/get_opts.py
@@ -55,6 +55,7 @@ new_parser = subparsers.add_parser('new', help='create a new sample retriever sc
 new_json_parser = subparsers.add_parser('new_json', help='CLI to create retriever datapackage.json script')
 edit_json_parser = subparsers.add_parser('edit_json', help='CLI to edit retriever datapackage.json script')
 delete_json_parser = subparsers.add_parser('delete_json', help='CLI to remove retriever datapackage.json script')
+autocreate_parser = subparsers.add_parser('autocreate', help='CLI to automatically create retriever scripts')
 ls_parser = subparsers.add_parser('ls', help='display a list all available dataset scripts')
 citation_parser = subparsers.add_parser('citation', help='view citation')
 license_parser = subparsers.add_parser('license', help='view dataset license')
@@ -87,6 +88,12 @@ ls_parser.add_argument('-k', help='search datasets with keyword(s)',
 ls_parser.add_argument('-v', help='verbose list of all datasets', nargs='*', default=False)
 
 delete_json_parser.add_argument('dataset', help='dataset name', choices=json_list)
+autocreate_parser.add_argument('path', help='path to the data file(s)')
+autocreate_parser.add_argument('-dt', help='datatype for files', nargs='?', default='tabular', choices=['raster', 'vector', 'tabular'])
+autocreate_parser.add_argument('-f', help='turn files into scripts', action='store_true')
+autocreate_parser.add_argument('-d', help='turn a directory and subdirectories into scripts', action='store_true')
+autocreate_parser.add_argument('-o', help='write scripts out to a designated directory', nargs='?', const='')
+autocreate_parser.add_argument('--skip-lines', help='skip a set number of lines before processing data', nargs=1, type=int)
 # retriever Install {Engine} ..
 # retriever download [options]
 install_subparsers = install_parser.add_subparsers(help='engine-specific help', dest='engine')


### PR DESCRIPTION
Automates script creation through CLI. 

Example test directory from which scripts are created:
![image](https://user-images.githubusercontent.com/15080652/55025276-04498200-4fd7-11e9-8af5-30bfaf55d61d.png)

![image](https://user-images.githubusercontent.com/15080652/55024989-5b028c00-4fd6-11e9-899b-589a0c989341.png)

the command is `retriever autocreate` followed by the path to directory to be turned into scripts. Adding a -d flag will make it so that we only create scripts for directories within that directory and all single files within a directory are turned into tables under a script with the name of the directory. 

In the example above, nested.json is a script containing two tables: iris and sby.

Without the -d flag, all single data files are turned into individual scripts. 

Works by creating a directory and putting data files into it, then calling this CLI on that directory. Feel free to ask questions, or suggest improvements!