### PR TITLE
use open_fr instead of open

### DIFF
--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -60,7 +60,7 @@ def reload_scripts():
         files = [file for file in os.listdir(search_path)
                  if file[-3:] == ".py" and file[0] != "_" and
                  ('#retriever' in
-                  ' '.join(open(join(search_path, file), 'r').readlines()[:2]).lower())
+                  ' '.join(open_fr(join(search_path, file), encoding=ENCODING).readlines()[:2]).lower())
                  ]
 
         for script in files:


### PR DESCRIPTION
I found the problem when running this on windows
![default](https://user-images.githubusercontent.com/44888393/53677284-5fde6380-3ce8-11e9-9f32-0b8de2e8b3e2.PNG)
I think that is due to the default decoding type in windows is gbk, and I think we should explicitly use ENCODING.
After changing, it can give the correct result.
![default](https://user-images.githubusercontent.com/44888393/53677316-d24f4380-3ce8-11e9-916b-8d28649f0339.PNG)


Thanks for your kindly reviewing