### PR TITLE
Return OrderedDict in fetch_tables in retriever/engines/sqlite.py

### DIFF
--- a/retriever/engines/sqlite.py
+++ b/retriever/engines/sqlite.py
@@ -45,10 +45,12 @@ class engine(Engine):
     def fetch_tables(self, dataset, table_names):
         """Return sqlite dataset as list of pandas dataframe."""
         connection = self.get_connection()
-        data = OrderedDict({table[len(dataset) + 1:]: pd.read_sql_query("SELECT * "
-                                                                        "FROM {};".format(table),
-                                                                        connection)
-                            for table in table_names})
+        sql_query = "SELECT * FROM {};"
+        data = OrderedDict({
+                    table[len(dataset) + 1:]
+                    :pd.read_sql_query(sql_query.format(table),connection)
+                    for table in table_names
+               })
         return data
 
     def get_bulk_insert_statement(self):

--- a/retriever/engines/sqlite.py
+++ b/retriever/engines/sqlite.py
@@ -48,7 +48,7 @@ class engine(Engine):
         sql_query = "SELECT * FROM {};"
         data = OrderedDict({
                     table[len(dataset) + 1:]
-                    :pd.read_sql_query(sql_query.format(table),connection)
+                    :pd.read_sql_query(sql_query.format(table), connection)
                     for table in table_names
                })
         return data

--- a/retriever/engines/sqlite.py
+++ b/retriever/engines/sqlite.py
@@ -1,6 +1,7 @@
 import os
 import pandas as pd
 from builtins import range
+from collections import OrderedDict
 
 from retriever.lib.defaults import DATA_DIR
 from retriever.lib.models import Engine, no_cleanup
@@ -44,10 +45,10 @@ class engine(Engine):
     def fetch_tables(self, dataset, table_names):
         """Return sqlite dataset as list of pandas dataframe."""
         connection = self.get_connection()
-        data = {table[len(dataset) + 1:]: pd.read_sql_query("SELECT * "
-                                                            "FROM {};".format(table),
-                                                            connection)
-                for table in table_names}
+        data = OrderedDict({table[len(dataset) + 1:]: pd.read_sql_query("SELECT * "
+                                                                        "FROM {};".format(table),
+                                                                        connection)
+                            for table in table_names})
         return data
 
     def get_bulk_insert_statement(self):


### PR DESCRIPTION
Resolves #1266

- Default `dict` doesn't maintain order of key value pairs
  i.e. in fetch_tables function, all rows of the table are getting
  populated into a `dictionary`, but we may need the data in the order
  in which the rows actually exist in the database.
- To facilitate this, `OrderedDict` from `collections` has been used. It
  maintains the order in which the values are assigned to corresponding
  keys.