### PR TITLE
Fix flat file installs into non-default directories

### DIFF
--- a/retriever/engines/csvengine.py
+++ b/retriever/engines/csvengine.py
@@ -40,11 +40,12 @@ class engine(Engine):
     def create_table(self):
         """Create the table by creating an empty csv file"""
         self.auto_column_number = 1
-        self.file = open_fw(os.path.join(self.opts["data_dir"], self.table_name()))
+        table_path = os.path.join(self.opts["data_dir"], self.table_name())
+        self.file = open_fw(table_path)
         self.output_file = open_csvw(self.file)
         column_list = self.table.get_insert_columns(join=False, create=True)
         self.output_file.writerow([u'{}'.format(val) for val in column_list])
-        self.table_names.append((self.file, self.table_name()))
+        self.table_names.append((self.file, table_path))
 
         # Register all tables created to enable
         # testing python files having custom download function

--- a/retriever/engines/jsonengine.py
+++ b/retriever/engines/jsonengine.py
@@ -43,9 +43,10 @@ class engine(Engine):
 
     def create_table(self):
         """Create the table by creating an empty json file"""
-        self.output_file = open_fw(os.path.join(self.opts["data_dir"], self.table_name()))
+        table_path = os.path.join(self.opts["data_dir"], self.table_name())
+        self.output_file = open_fw(table_path)
         self.output_file.write("[")
-        self.table_names.append((self.output_file, self.table_name()))
+        self.table_names.append((self.output_file, table_path))
         self.auto_column_number = 1
 
         # Register all tables created to enable

--- a/retriever/engines/xmlengine.py
+++ b/retriever/engines/xmlengine.py
@@ -39,10 +39,11 @@ class engine(Engine):
 
     def create_table(self):
         """Create the table by creating an empty XML file."""
-        self.output_file = open_fw(os.path.join(self.opts["data_dir"], self.table_name()))
+        table_path = os.path.join(self.opts["data_dir"], self.table_name())
+        self.output_file = open_fw(table_path)
         self.output_file.write(u'<?xml version="1.0" encoding="UTF-8"?>')
         self.output_file.write(u'\n<root>')
-        self.table_names.append((self.output_file, self.table_name()))
+        self.table_names.append((self.output_file, table_path))
         self.auto_column_number = 1
 
         # Register all tables created to enable


### PR DESCRIPTION
The new `data_dir` option wasn't added to the `table_names` list that is
used for disconnecting the flat file engines. This was leading to "No such file"
errors and files that weren't getting disconnected.

Fixes #1263