### PR TITLE
Engine should contain only the current tables processed

### DIFF
--- a/retriever/lib/install.py
+++ b/retriever/lib/install.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
+from collections import OrderedDict
 
 from retriever.engines import choose_engine
 from retriever.lib.defaults import DATA_DIR, SCRIPT_WRITE_PATH
@@ -23,6 +24,7 @@ def _install(args, use_cache, debug):
     if data_sets_scripts:
         for data_sets_script in data_sets_scripts:
             try:
+                engine.script_table_registry = OrderedDict()
                 data_sets_script.download(engine, debug=debug)
                 data_sets_script.engine.final_cleanup()
             except Exception as e:

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -246,3 +246,12 @@ def test_fetch():
                 first_row_data = list(data_frame[table_i].iloc[0])
                 assert expected_data == first_row_data
                 assert expected_column_values == column_values
+
+
+def test_interface_table_registry():
+    # Test if script_table_registry keeps only the latest
+    # table names of the installed data packages in
+    # script_table_registry
+    install_csv("iris")
+    wine_data = fetch("wine-composition")
+    assert "iris" not in wine_data.keys()


### PR DESCRIPTION
Add interface test for script table registry
Test if script_table_registry keeps only the latest
table names of the installed data packages in 
script_table_registry