### PR TITLE
Change python encoding from latin-1 to UTF-8 defined using PEP 263

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1  -*-
+# -*- coding: UTF-8  -*-
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/scripts/flensburg_food_web.py
+++ b/scripts/flensburg_food_web.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1 -*-
+# -*- coding: UTF-8 -*-
 #retriever
 from pkg_resources import parse_version
 

--- a/scripts/socean_diet_data.py
+++ b/scripts/socean_diet_data.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1 -*-
+# -*- coding: UTF-8 -*-
 #retriever
 from pkg_resources import parse_version
 

--- a/scripts/vertnet.py
+++ b/scripts/vertnet.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1 -*-
+# -*- coding: UTF-8 -*-
 #retriever
 
 """Retriever script for direct download of vertnet data"""

--- a/scripts/vertnet_amphibians.py
+++ b/scripts/vertnet_amphibians.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1 -*-
+# -*- coding: UTF-8 -*-
 #retriever
 
 """Retriever script for direct download of vertnet-amphibians data"""

--- a/scripts/vertnet_birds.py
+++ b/scripts/vertnet_birds.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1 -*-
+# -*- coding: UTF-8 -*-
 #retriever
 
 """Retriever script for direct download of vertnet-birds data"""

--- a/scripts/vertnet_fishes.py
+++ b/scripts/vertnet_fishes.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1 -*-
+# -*- coding: UTF-8 -*-
 #retriever
 
 """Retriever script for direct download of vertnet-fishes data"""

--- a/scripts/vertnet_mammals.py
+++ b/scripts/vertnet_mammals.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1 -*-
+# -*- coding: UTF-8 -*-
 #retriever
 
 """Retriever script for direct download of vertnet-mammals data"""

--- a/scripts/vertnet_reptiles.py
+++ b/scripts/vertnet_reptiles.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1 -*-
+# -*- coding: UTF-8 -*-
 #retriever
 
 """Retriever script for direct download of vertnet-reptiles data"""

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1  -*-
+# -*- coding: UTF-8  -*-
 # """Integrations tests for Data Retriever"""
 from __future__ import print_function
 
@@ -139,7 +139,7 @@ data_no_header = {
 csv_latin1_encoding = {
     'name': 'csv_latin1_encoding',
     'raw_data': ['a,b,c',
-                 u'1,2,4Löve',
+                 u'1,2,4Lï¿½ve',
                  '4,5,6'],
     'script': {"name": "csv_latin1_encoding",
                "resources": [
@@ -157,7 +157,7 @@ csv_latin1_encoding = {
                         "http://example.com/csv_latin1_encoding.txt"
                     }
                },
-    'expect_out': [u'a,b,c', u'1,2,4Löve', u'4,5,6']
+    'expect_out': [u'a,b,c', u'1,2,4Lï¿½ve', u'4,5,6']
 }
 
 autopk_csv = {

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1  -*-
+# -*- coding: UTF-8  -*-
 """Tests for the Data Retriever"""
 from future import standard_library
 
@@ -105,7 +105,7 @@ def test_auto_get_datatypes():
     The function adds 100 to the auto detected length of column
     """
     test_engine.auto_get_datatypes(None,
-                                   [["ö", 'bb', 'Löve']],
+                                   [["ï¿½", 'bb', 'Lï¿½ve']],
                                    [['a', None], ['b', None], ['c', None]])
     length = test_engine.table.columns
     assert [length[0][1][1], length[1][1][1], length[2][1][1]] == \


### PR DESCRIPTION
<div>All references to # -*- coding: latin-1  -*- were replaced by # -*- coding: UTF-8  -*- </div>
<br>
Fulfills task2 of #1277 (probably not exhaustively)