### PR TITLE
Add HDF5 engine using Pandas and SQLite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sphinxcontrib-napoleon
 sphinx_rtd_theme
 tqdm==4.30.0
 pandas
+tables

--- a/retriever/__main__.py
+++ b/retriever/__main__.py
@@ -196,6 +196,18 @@ def main():
             for dataset in scripts:
                 print("=> Installing", dataset.name)
                 try:
+                    if engine.name == "HDF5":
+                        sqlite_opts = {
+                            'command': 'install',
+                            'dataset': dataset,
+                            'engine': 'sqlite',
+                            'file': (args.file.split("."))[0] + ".db",
+                            'table_name': args.table_name,
+                            'data_dir': args.data_dir
+                        }
+                        sqlite_engine = choose_engine(sqlite_opts)
+                        dataset.download(sqlite_engine, debug=debug)
+                        dataset.engine.final_cleanup()
                     dataset.download(engine, debug=debug)
                     dataset.engine.final_cleanup()
                 except KeyboardInterrupt:

--- a/retriever/engines/__init__.py
+++ b/retriever/engines/__init__.py
@@ -11,7 +11,8 @@ engines = [
     "csvengine",
     "download_only",
     "jsonengine",
-    "xmlengine"
+    "xmlengine",
+    "hdf5"
 ]
 
 engine_module_list = [

--- a/retriever/engines/hdf5.py
+++ b/retriever/engines/hdf5.py
@@ -1,0 +1,65 @@
+import os
+
+from pandas import HDFStore
+
+from retriever.lib.defaults import DATA_DIR
+from retriever.lib.dummy import DummyConnection
+from retriever.lib.models import Engine
+
+
+class engine(Engine):
+    """Engine instance for writing data to a HDF5 file."""
+
+    name = "HDF5"
+    abbreviation = "hdf5"
+    insert_limit = 1000
+    required_opts = [
+        ("file",
+         "Enter the filename of your HDF5 file",
+         "hdf5.h5"),
+        ("table_name",
+         "Format of table name",
+         "{db}_{table}"),
+        ("data_dir",
+         "Install directory",
+         DATA_DIR),
+    ]
+
+    def create_db(self):
+        """Override create_db since an SQLite dataset needs to be created
+        first followed by the creation of an empty HDFStore file.
+        """
+        from retriever.engines.sqlite import engine
+
+        self.dbname = self.script.name.lower()
+        self.sqlite_engine = engine()
+        self.sqlite_engine.opts = {"file": self.opts["file"].split(".")[0] + ".db",
+                                   "table_name": self.opts["table_name"],
+                                   "data_dir": self.opts["data_dir"]}
+        file_path = os.path.join(self.opts["data_dir"], self.opts["file"])
+        self.file = HDFStore(file_path)
+
+    def create_table(self):
+        """Don't create table for HDF5
+
+        HDF5 doesn't create tables. Each database is a file which has been
+        created. This overloads`create_table` to do nothing in this case.
+        """
+        return None
+
+    def insert_data_from_file(self, filename):
+        """Fill the table by fetching the dataframe from the
+        SQLite engine and putting it into the HDFStore file.
+        """
+        table_name = self.table_name()
+        df = self.sqlite_engine.fetch_table(table_name)
+        self.file.put(table_name, df, data_columns=True)
+
+    def get_connection(self):
+        """Gets the db connection."""
+        self.get_input()
+        return DummyConnection()
+
+    def disconnect(self):
+        """Close the file after being written"""
+        self.file.close()

--- a/retriever/engines/sqlite.py
+++ b/retriever/engines/sqlite.py
@@ -53,6 +53,12 @@ class engine(Engine):
                ])
         return data
 
+    def fetch_table(self, table_name):
+        """Return a table from sqlite dataset as pandas dataframe."""
+        connection = self.get_connection()
+        sql_query = "SELECT * FROM {};".format(table_name)
+        return pd.read_sql_query(sql_query, connection)
+
     def get_bulk_insert_statement(self):
         """Get insert statement for bulk inserts
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -32,7 +32,7 @@ else:
     os_password = ""
 
 mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, \
-csv_engine, download_engine, json_engine, xml_engine = engine_list
+csv_engine, download_engine, json_engine, xml_engine, _ = engine_list
 
 simple_csv = {
     'name': 'simple_csv',

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -37,7 +37,7 @@ else:
     os_password = ''
 
 mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, \
-csv_engine, download_engine, json_engine, xml_engine = engine_list
+csv_engine, download_engine, json_engine, xml_engine, _ = engine_list
 file_location = os.path.dirname(os.path.realpath(__file__))
 retriever_root_dir = os.path.abspath(os.path.join(file_location, os.pardir))
 working_script_dir = os.path.abspath(os.path.join(retriever_root_dir, "scripts"))


### PR DESCRIPTION
This pull request aims to fix: #79. It tries to add HDF5 engine by installing a database in SQLite as an intermediary step, and then using pandas to create HDFStore file. I chose SQLite over CSV as it allows high speed bulk insert operation.  