### PR TITLE
Solve None error in json dump

### DIFF
--- a/retriever/lib/datapackage.py
+++ b/retriever/lib/datapackage.py
@@ -247,9 +247,9 @@ def create_json():
     file_name = contents['name'] + ".json"
     file_name = file_name.replace('-', '_')
     with open(os.path.join(HOME_DIR, 'scripts', file_name), 'w') as output_file:
-        json_str = str(json.dump(contents, output_file, sort_keys=True, indent=4,
-                              separators=(',', ': ')))
-        output_file.write(json_str + '\n')
+        json.dump(contents, output_file, sort_keys=True, indent=4,
+                  separators=(',', ': '))
+        output_file.write('\n')
         print("\nScript written to " + file_name)
         output_file.close()
 
@@ -426,9 +426,9 @@ def edit_json(json_file):
     file_name = contents['name'] + ".json"
     file_name = file_name.replace('-', '_')
     with open(os.path.join(HOME_DIR, 'scripts', file_name), 'w') as output_file:
-        json_str = str(json.dump(contents, output_file, sort_keys=True, indent=4,
-                              separators=(',', ': ')))
-        output_file.write(json_str + '\n')
+        json.dump(contents, output_file, sort_keys=True, indent=4,
+                  separators=(',', ': '))
+        output_file.write('\n')
         print("\nScript written to " +
               os.path.join(HOME_DIR, 'scripts', file_name))
         output_file.close()

--- a/retriever/lib/datapackage.py
+++ b/retriever/lib/datapackage.py
@@ -258,7 +258,7 @@ def edit_dict(obj, tabwidth=0):
     """
     Recursive helper function for edit_json() to edit a datapackage.JSON script file.
     """
-    for key, val in obj.items():
+    for key, val in obj.copy().items():
         print('\n' + "  " * tabwidth + "->" + key + " (", type(val), ") :\n")
         if isinstance(val, list):
             for v in val:


### PR DESCRIPTION
Presently, when a script is created or edited via `new_json` or `edit_json`, `None` is appended at the end. It is due to the line `output_file.write(json_str + '\n')`, where `json_str` is None. Currently, `json_str = str(json.dump(contents, output_file, sort_keys=True, indent=4, separators=(',', ': ')))` is called, but `json.dump()` itself writes the json formatted stream to the file. Thus, it returns None (which eventually gets assigned to `json_str`). This pull request aims to fix this. Please correct me if I am wrong. 