### PR TITLE
Remove urls attribute from sample script

### DIFF
--- a/retriever/lib/defaults.py
+++ b/retriever/lib/defaults.py
@@ -39,10 +39,7 @@ sample_script = """
             "url": "http://esapubs.org/archive/ecol/E084/093/Mammal_lifehistories_v2.txt"
         }
     ],
-    "title": "Mammal Life History Database - Ernest, et al., 2003",
-    "urls": {
-        "species": "http://esapubs.org/archive/ecol/E084/093/Mammal_lifehistories_v2.txt"
-    }
+    "title": "Mammal Life History Database - Ernest, et al., 2003"
 }
 """
 CITATION = """Morris, B.D. and E.P. White. 2013. The EcoData Retriever: improving access to


### PR DESCRIPTION
We no longer use the `urls` attribute in the json scripts so I have removed it from the sample script too.