### PR TITLE
Gracefully handle failed downloads

### DIFF
--- a/retriever/engines/download_only.py
+++ b/retriever/engines/download_only.py
@@ -47,6 +47,8 @@ class engine(Engine):
                 if os.path.isfile(os.path.join(dest_path, file_name_nopath)):
                     print("File already exists at specified location")
                     print("Keeping existing copy.")
+                elif file_name_nopath[-5:] == ".part":
+                    pass
                 else:
                     try:
                         print("Copying %s from %s" % (file_name_nopath, file_path))

--- a/retriever/lib/engine.py
+++ b/retriever/lib/engine.py
@@ -19,6 +19,8 @@ import tarfile
 import csv
 import re
 import requests
+import shutil
+import hashlib
 from collections import OrderedDict
 from math import ceil
 from tqdm import tqdm
@@ -461,24 +463,99 @@ class Engine(object):
         """Download file to the raw data directory."""
         if not self.find_file(filename) or not self.use_cache:
             path = self.format_filename(filename)
-            self.create_raw_data_dir()
-            progbar = tqdm(unit='B',
-                           unit_scale=True,
-                           unit_divisor=1024,
-                           miniters=1,
-                           desc='Downloading {}'.format(filename))
             try:
-                requests.get(url, allow_redirects=True,
-                             stream=True,
-                             headers={'user-agent': 'Weecology/Data-Retriever \
-                                            Package Manager: http://www.data-retriever.org/'},
-                             hooks={'response': reporthook(progbar, path)})
+                head = requests.head(url).headers
+                file_size = int(head.get("Content-Length", -1))
+                print("Downloading: %s Bytes: %s" % (filename, file_size))
 
+                if file_size != -1 and file_size != 0 and \
+                        os.path.exists(path + '.part') and \
+                                file_size > os.path.getsize(path + '.part'):
+                    self.download_with_resume(url, path)
+                else:
+                    self.create_raw_data_dir()
+                    progbar = tqdm(unit='B',
+                                   unit_scale=True,
+                                   unit_divisor=1024,
+                                   miniters=1,
+                                   desc='Downloading {}'.format(filename))
+                    try:
+                        requests.get(url, allow_redirects=True,
+                                     stream=True,
+                                     headers={'user-agent': 'Weecology/Data-Retriever \
+                                                            Package Manager: http://www.data-retriever.org/'},
+                                     hooks={'response': reporthook(progbar, path)})
+                    except KeyboardInterrupt:
+                        print("KeyboardInterrupt")
+                        if os.path.exists(path) and os.path.getsize(path) < file_size:
+                            shutil.move(path, path + '.part')
+                    except InvalidSchema:
+                        urlretrieve(url, path, reporthook=reporthook(progbar))
+                    self.use_cache = True
+                    progbar.close()
             except InvalidSchema:
+                self.create_raw_data_dir()
+                progbar = tqdm(unit='B',
+                               unit_scale=True,
+                               unit_divisor=1024,
+                               miniters=1,
+                               desc='Downloading {}'.format(filename))
                 urlretrieve(url, path, reporthook=reporthook(progbar))
+                self.use_cache = True
+                progbar.close()
 
-            self.use_cache = True
+    def download_with_resume(self, url, file_path, hash=None, timeout=10):
+        """
+        Performs a HTTP(S) download that can be restarted if prematurely terminated.
+        The HTTP server must support byte ranges.
+
+        :param file_path: the path to the file to write to disk
+        :type file_path:  string
+        :param hash: hash value for file validation
+        :type hash:  string (MD5 hash value)
+        """
+        block_size = 1024 * 1024  # 1MB
+        tmp_file_path = file_path + '.part'
+        first_byte = os.path.getsize(tmp_file_path) if os.path.exists(tmp_file_path) else 0
+        print('Resuming downloading at %.1fMB' % (first_byte / 1024 / 1024))
+        file_size = -1
+        progbar = tqdm(unit='B',
+                       unit_scale=True,
+                       unit_divisor=1024,
+                       miniters=1,
+                       desc='Resuming downloading {}'.format(file_path[file_path.rfind('/') + 1:]))
+        try:
+            file_size = int(requests.head(url).headers.get('Content-Length', -1))
+            progbar.total = ceil(file_size // (2 * 1024))
+            progress = first_byte // (2 * 1024)
+            for times in range(progress):
+                progbar.update(1)
+            while first_byte < file_size:
+                last_byte = first_byte + block_size \
+                    if first_byte + block_size < file_size \
+                    else file_size
+                resume_header = {'Range': 'bytes=%s-%s' % (first_byte, last_byte),
+                                 'Accept-Encoding': 'deflate',
+                                 'user-agent': 'Weecology/Data-Retriever \
+                                        Package Manager: http://www.data-retriever.org/'}
+                req = requests.get(url, headers=resume_header, stream=True)
+                with open(tmp_file_path, 'ab') as f:
+                    for chunk in req.iter_content(2 * 1024):
+                        f.write(chunk)
+                        progbar.update(1)
+                first_byte = last_byte + 1
+        except IOError as e:
+            print('IO Error - %s' % e)
+        except InvalidSchema:
+            urlretrieve(url, tmp_file_path, reporthook=reporthook(progbar))
+        finally:
             progbar.close()
+            if file_size == os.path.getsize(tmp_file_path):
+                if hash and not validate_file(tmp_file_path, hash):
+                    raise Exception('Error validating the file against its MD5 hash')
+                shutil.move(tmp_file_path, file_path)
+            elif file_size == -1:
+                raise Exception('Error getting Content-Length from server: %s' % url)
 
     def download_files_from_archive(self, url,
                                     file_names=None, archive_type="zip",
@@ -988,3 +1065,21 @@ def reporthook(tqdm_inst, filename=None):
         f.close()
 
     return update_rto if filename else update_to
+
+def validate_file(file_path, hash):
+    """
+    Validates a file against an MD5 hash value
+
+    :param file_path: path to the file for hash validation
+    :type file_path:  string
+    :param hash:      expected hash value of the file
+    :type hash:       string -- MD5 hash value
+    """
+    m = hashlib.md5()
+    with open(file_path, 'rb') as f:
+        while True:
+            chunk = f.read(1000 * 1000)  # 1MB
+            if not chunk:
+                break
+            m.update(chunk)
+    return m.hexdigest() == hash


### PR DESCRIPTION
In most case, we meet failed download problem #903 due to network interrupts and we always terminate the command by KeyboardInterrupt. To solve the problem cause by this reason, I rename partial downloaded data as 'filename.part' file. When the data is downloaded completely, 'filename.part' file will be moved to 'filename' file. I test airports dataset and it works well. However, some datasets do not contain 'content-length' element in headers, I do not find way to resume downloading this type of data. I am glad that you can provide suggestion to my code. Thank you! @henrykironde @ethanwhite