### PR TITLE
Changing os.system to subprocess.call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import os
 import re
 import platform
+import subprocess
 
 from pkg_resources import parse_version
 from setuptools import setup, find_packages
@@ -14,8 +15,8 @@ if current_platform == "windows":
     extra_includes += ["pypyodbc"]
 
 if os.path.exists(".git/hooks"):  # check if we are in git repo
-    os.system("cp hooks/pre-commit .git/hooks/pre-commit")
-    os.system("chmod +x .git/hooks/pre-commit")
+    subprocess.call("cp hooks/pre-commit .git/hooks/pre-commit", shell=True)
+    subprocess.call("chmod +x .git/hooks/pre-commit", shell=True)
 
 app_data = "~/.retriever/scripts"
 if os.path.exists(app_data):


### PR DESCRIPTION
Noticed that os.system wasn't working in our setup.py. 

This is likely due to the missing ```#!/usr/bin/env python``` at the top of setup.py, but we can keep the top of setup.py the same if we use subprocess calls in place of os.system. Subprocess calls seem like the python standard for making shell calls, and this might be a bigger discussion about changing the rest of our leftover os.system calls to subprocess.call calls. 