### PR TITLE
Use newer Python for testing by updating to Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-# Download base image ubuntu 16.04
-FROM ubuntu:16.04
+# Download base image ubuntu 18.04
+FROM ubuntu:18.04
 
 MAINTAINER Weecology "https://github.com/weecology/retriever"
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
+# Manually install tzdata to allow for non-interactive install
+RUN apt-get install -y --force-yes tzdata
+
 RUN apt-get install -y --force-yes build-essential wget git locales locales-all > /dev/null
 RUN apt-get install -y --force-yes postgresql-client mysql-client > /dev/null
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
     image: ret_image
     command: bash -c "Python --version"
     environment:
+      # Handle tzdata install see: https://serverfault.com/a/975084
+      TZ: America/New_York
+      DEBIAN_FRONTEND: noninteractive
       # If IN_DOCKER is set, use service names as hosts(travis)
       # Otherwise use localhost (local tests)
       "IN_DOCKER" : "true"


### PR DESCRIPTION
Due to Pandas no longer supporting older Python versions the Travis builds are now failing.
This updates the base image to Ubuntu 18.04, which brings Python 3 up to 3.6.8 where everything
works as expected.

This requires some additional changes to allow the `apt` package `tzdata` to be installed without user interaction. 

Fixes #1361.