### PR TITLE
Add installation of committed datasets stored in provenance directory

### DIFF
--- a/retriever/__main__.py
+++ b/retriever/__main__.py
@@ -232,8 +232,9 @@ def main():
         else:
             raise Exception("no dataset specified.")
         if scripts:
-            if args.dataset.endswith('.zip'):
+            if args.dataset.endswith('.zip') or args.hash:
                 _install(vars(args), debug=debug, use_cache=use_cache)
+                return
             else:
                 for dataset in scripts:
                     print("=> Installing", dataset.name)

--- a/retriever/lib/get_opts.py
+++ b/retriever/lib/get_opts.py
@@ -79,6 +79,7 @@ reset_parser.add_argument('scope', help='things to reset: all, scripts or data')
 install_parser.add_argument('--compile', help='force re-compile of script before downloading', action='store_true')
 install_parser.add_argument('--debug', help='run in debug mode', action='store_true')
 install_parser.add_argument('--not-cached', help='overwrites local cache of raw data', action='store_true')
+install_parser.add_argument('--hash', help='install dataset from provenance directory using hash', default=None, nargs=1, required=False, type=str)
 download_parser.add_argument('--debug', help='run in debug mode', action='store_true')
 download_parser.add_argument('--not-cached', help='overwrites local cache of raw data', action='store_true')
 download_parser.add_argument('-b', '--bbox', nargs=4,
@@ -110,6 +111,8 @@ for engine in engine_list:
     else:
         engine_parser = install_subparsers.add_parser(engine.abbreviation, help=engine.name)
         engine_parser.add_argument('dataset', help='dataset name').completer = ChoicesCompleter(script_list)
+        engine_parser.add_argument('--hash', help='install dataset from provenance directory using hash', default=None,
+                                    nargs=1, required=False, type=str)
         engine_parser.add_argument('-b', '--bbox', nargs=4,
                                    help='Set bounding box xmin, ymin, xmax, ymax',
                                    required=False)

--- a/retriever/lib/install.py
+++ b/retriever/lib/install.py
@@ -5,21 +5,26 @@ import os
 from collections import OrderedDict
 
 from retriever.engines import choose_engine
-from retriever.lib.defaults import DATA_DIR, SCRIPT_WRITE_PATH
+from retriever.lib.defaults import DATA_DIR, SCRIPT_WRITE_PATH, PROVENANCE_DIR
 from retriever.lib.scripts import SCRIPT_LIST, name_matches
 from retriever.lib.repository import check_for_updates
 from retriever.lib.provenance import install_committed
 
 
-def _install(args, use_cache, debug, force=False):
+def _install(args, use_cache, debug):
     """Install datasets for retriever."""
     engine = choose_engine(args)
     engine.use_cache = use_cache
 
-    if args['dataset'].endswith('.zip'):
-        install_committed(args['dataset'], engine, force=force)
+    if args['dataset'].endswith('.zip') or args['hash']:
+        path_to_archive = args['dataset']
+        if args['hash']:
+            path_to_archive = os.path.join(PROVENANCE_DIR, args['dataset'],
+                                           '{}-{}.zip'.format(args['dataset'], args['hash'][0]))
+        if not os.path.exists(path_to_archive):
+            print('The committed file does not exist.')
+        engine = install_committed(path_to_archive, engine, force=args['force'])
         return engine
-
     script_list = SCRIPT_LIST()
     if not (script_list or os.listdir(SCRIPT_WRITE_PATH)):
         check_for_updates()
@@ -44,21 +49,23 @@ def _install(args, use_cache, debug, force=False):
 
 def install_csv(dataset,
                 table_name='{db}_{table}.csv',
-                data_dir=DATA_DIR, debug=False, use_cache=True, force=False):
+                data_dir=DATA_DIR, debug=False, use_cache=True, force=False, hash=None):
     """Install datasets into csv."""
     args = {
         'command': 'install',
         'dataset': dataset,
         'engine': 'csv',
         'table_name': table_name,
-        'data_dir': data_dir
+        'data_dir': data_dir,
+        'force': force,
+        'hash': hash
     }
-    return _install(args, use_cache, debug, force=force)
+    return _install(args, use_cache, debug)
 
 
 def install_mysql(dataset, user='root', password='', host='localhost',
                   port=3306, database_name='{db}', table_name='{db}.{table}',
-                  debug=False, use_cache=True, force=False):
+                  debug=False, use_cache=True, force=False, hash=None):
     """Install datasets into mysql."""
     args = {
         'command': 'install',
@@ -69,15 +76,17 @@ def install_mysql(dataset, user='root', password='', host='localhost',
         'port': port,
         'password': password,
         'table_name': table_name,
-        'user': user
+        'user': user,
+        'force': force,
+        'hash': hash
     }
-    return _install(args, use_cache, debug, force=force)
+    return _install(args, use_cache, debug)
 
 
 def install_postgres(dataset, user='postgres', password='',
                      host='localhost', port=5432, database='postgres',
                      database_name='{db}', table_name='{db}.{table}', bbox=[],
-                     debug=False, use_cache=True, force=False):
+                     debug=False, use_cache=True, force=False, hash=None):
     """Install datasets into postgres."""
     args = {
         'command': 'install',
@@ -90,15 +99,17 @@ def install_postgres(dataset, user='postgres', password='',
         'password': password,
         'table_name': table_name,
         'user': user,
-        'bbox': bbox
+        'bbox': bbox,
+        'force': force,
+        'hash': hash
     }
-    return _install(args, use_cache, debug, force=force)
+    return _install(args, use_cache, debug)
 
 
 def install_sqlite(dataset, file='sqlite.db',
                    table_name='{db}_{table}',
                    data_dir=DATA_DIR,
-                   debug=False, use_cache=True, force=False):
+                   debug=False, use_cache=True, force=False, hash=None):
     """Install datasets into sqlite."""
     args = {
         'command': 'install',
@@ -106,15 +117,17 @@ def install_sqlite(dataset, file='sqlite.db',
         'engine': 'sqlite',
         'file': file,
         'table_name': table_name,
-        'data_dir': data_dir
+        'data_dir': data_dir,
+        'force': force,
+        'hash': hash
     }
-    return _install(args, use_cache, debug, force=force)
+    return _install(args, use_cache, debug)
 
 
 def install_msaccess(dataset, file='access.mdb',
                      table_name='[{db} {table}]',
                      data_dir=DATA_DIR,
-                     debug=False, use_cache=True, force=False):
+                     debug=False, use_cache=True, force=False, hash=None):
     """Install datasets into msaccess."""
     args = {
         'command': 'install',
@@ -122,14 +135,16 @@ def install_msaccess(dataset, file='access.mdb',
         'engine': 'msaccess',
         'file': file,
         'table_name': table_name,
-        'data_dir': data_dir
+        'data_dir': data_dir,
+        'force': force,
+        'hash': hash
     }
-    return _install(args, use_cache, debug, force=force)
+    return _install(args, use_cache, debug)
 
 
 def install_json(dataset,
                  table_name='{db}_{table}.json',
-                 data_dir=DATA_DIR, debug=False, use_cache=True, pretty=False, force=False):
+                 data_dir=DATA_DIR, debug=False, use_cache=True, pretty=False, force=False, hash=None):
     """Install datasets into json."""
     args = {
         'command': 'install',
@@ -137,20 +152,24 @@ def install_json(dataset,
         'engine': 'json',
         'table_name': table_name,
         'data_dir': data_dir,
-        'pretty': pretty
+        'pretty': pretty,
+        'force': force,
+        'hash': hash
     }
-    return _install(args, use_cache, debug, force=force)
+    return _install(args, use_cache, debug)
 
 
 def install_xml(dataset,
                 table_name='{db}_{table}.xml',
-                data_dir=DATA_DIR, debug=False, use_cache=True, force=False):
+                data_dir=DATA_DIR, debug=False, use_cache=True, force=False, hash=None):
     """Install datasets into xml."""
     args = {
         'command': 'install',
         'dataset': dataset,
         'engine': 'xml',
         'table_name': table_name,
-        'data_dir': data_dir
+        'data_dir': data_dir,
+        'force': force,
+        'hash': hash
     }
-    return _install(args, use_cache, debug, force=force)
+    return _install(args, use_cache, debug)


### PR DESCRIPTION
Assumption: If a hash is provided when installing dataset it means it has to be installed from the 
provenance directory.
The hash value of a commit can be obtained using `retriever log dataset_name`

Usage for installation:
```bash
retriever install sqlite abalone-age --hash 02ee77
```
```python
from retriever import install_csv
install_csv('abalone-age', hash='02ee77')
```