### PR TITLE
Allow installation of committed dataset with python script

### DIFF
--- a/retriever/__main__.py
+++ b/retriever/__main__.py
@@ -232,7 +232,7 @@ def main():
         else:
             raise Exception("no dataset specified.")
         if scripts:
-            if args.dataset.endswith('.zip') or args.hash:
+            if args.dataset.endswith('.zip') or args.hash_value:
                 _install(vars(args), debug=debug, use_cache=use_cache)
                 return
             else:

--- a/retriever/lib/engine.py
+++ b/retriever/lib/engine.py
@@ -504,7 +504,7 @@ class Engine(object):
                 file_names = self.extract_gz(archive_full_path, archive_dir)
             return file_names
 
-        archive_downloaded = False
+        archive_downloaded = True if self.data_path else False
         for file_name in file_names:
             archive_full_path = self.format_filename(archive_name)
             if not self.find_file(os.path.join(archive_dir, file_name)):
@@ -657,6 +657,8 @@ class Engine(object):
 
     def format_data_dir(self):
         """Return correctly formatted raw data directory location."""
+        if self.data_path:
+            return os.path.join(self.data_path, self.script.name)
         return DATA_WRITE_PATH.format(dataset=self.script.name)
 
     def format_filename(self, filename):

--- a/retriever/lib/get_opts.py
+++ b/retriever/lib/get_opts.py
@@ -79,7 +79,6 @@ reset_parser.add_argument('scope', help='things to reset: all, scripts or data')
 install_parser.add_argument('--compile', help='force re-compile of script before downloading', action='store_true')
 install_parser.add_argument('--debug', help='run in debug mode', action='store_true')
 install_parser.add_argument('--not-cached', help='overwrites local cache of raw data', action='store_true')
-install_parser.add_argument('--hash', help='install dataset from provenance directory using hash', default=None, nargs=1, required=False, type=str)
 download_parser.add_argument('--debug', help='run in debug mode', action='store_true')
 download_parser.add_argument('--not-cached', help='overwrites local cache of raw data', action='store_true')
 download_parser.add_argument('-b', '--bbox', nargs=4,
@@ -111,7 +110,7 @@ for engine in engine_list:
     else:
         engine_parser = install_subparsers.add_parser(engine.abbreviation, help=engine.name)
         engine_parser.add_argument('dataset', help='dataset name').completer = ChoicesCompleter(script_list)
-        engine_parser.add_argument('--hash', help='install dataset from provenance directory using hash', default=None,
+        engine_parser.add_argument('--hash-value', help='install dataset from provenance directory using hash value', default=None,
                                     nargs=1, required=False, type=str)
         engine_parser.add_argument('-b', '--bbox', nargs=4,
                                    help='Set bounding box xmin, ymin, xmax, ymax',

--- a/retriever/lib/install.py
+++ b/retriever/lib/install.py
@@ -16,11 +16,11 @@ def _install(args, use_cache, debug):
     engine = choose_engine(args)
     engine.use_cache = use_cache
 
-    if args['dataset'].endswith('.zip') or args['hash']:
+    if args['dataset'].endswith('.zip') or args['hash_value']:
         path_to_archive = args['dataset']
-        if args['hash']:
+        if args['hash_value']:
             path_to_archive = os.path.join(PROVENANCE_DIR, args['dataset'],
-                                           '{}-{}.zip'.format(args['dataset'], args['hash'][0]))
+                                           '{}-{}.zip'.format(args['dataset'], args['hash_value'][0]))
         if not os.path.exists(path_to_archive):
             print('The committed file does not exist.')
         engine = install_committed(path_to_archive, engine, force=args.get('force', False))
@@ -49,7 +49,7 @@ def _install(args, use_cache, debug):
 
 def install_csv(dataset,
                 table_name='{db}_{table}.csv',
-                data_dir=DATA_DIR, debug=False, use_cache=True, force=False, hash=None):
+                data_dir=DATA_DIR, debug=False, use_cache=True, force=False, hash_value=None):
     """Install datasets into csv."""
     args = {
         'command': 'install',
@@ -58,14 +58,14 @@ def install_csv(dataset,
         'table_name': table_name,
         'data_dir': data_dir,
         'force': force,
-        'hash': hash
+        'hash_value': hash_value
     }
     return _install(args, use_cache, debug)
 
 
 def install_mysql(dataset, user='root', password='', host='localhost',
                   port=3306, database_name='{db}', table_name='{db}.{table}',
-                  debug=False, use_cache=True, force=False, hash=None):
+                  debug=False, use_cache=True, force=False, hash_value=None):
     """Install datasets into mysql."""
     args = {
         'command': 'install',
@@ -78,7 +78,7 @@ def install_mysql(dataset, user='root', password='', host='localhost',
         'table_name': table_name,
         'user': user,
         'force': force,
-        'hash': hash
+        'hash_value': hash_value
     }
     return _install(args, use_cache, debug)
 
@@ -86,7 +86,7 @@ def install_mysql(dataset, user='root', password='', host='localhost',
 def install_postgres(dataset, user='postgres', password='',
                      host='localhost', port=5432, database='postgres',
                      database_name='{db}', table_name='{db}.{table}', bbox=[],
-                     debug=False, use_cache=True, force=False, hash=None):
+                     debug=False, use_cache=True, force=False, hash_value=None):
     """Install datasets into postgres."""
     args = {
         'command': 'install',
@@ -101,7 +101,7 @@ def install_postgres(dataset, user='postgres', password='',
         'user': user,
         'bbox': bbox,
         'force': force,
-        'hash': hash
+        'hash_value': hash_value
     }
     return _install(args, use_cache, debug)
 
@@ -109,7 +109,7 @@ def install_postgres(dataset, user='postgres', password='',
 def install_sqlite(dataset, file='sqlite.db',
                    table_name='{db}_{table}',
                    data_dir=DATA_DIR,
-                   debug=False, use_cache=True, force=False, hash=None):
+                   debug=False, use_cache=True, force=False, hash_value=None):
     """Install datasets into sqlite."""
     args = {
         'command': 'install',
@@ -119,7 +119,7 @@ def install_sqlite(dataset, file='sqlite.db',
         'table_name': table_name,
         'data_dir': data_dir,
         'force': force,
-        'hash': hash
+        'hash_value': hash_value
     }
     return _install(args, use_cache, debug)
 
@@ -127,7 +127,7 @@ def install_sqlite(dataset, file='sqlite.db',
 def install_msaccess(dataset, file='access.mdb',
                      table_name='[{db} {table}]',
                      data_dir=DATA_DIR,
-                     debug=False, use_cache=True, force=False, hash=None):
+                     debug=False, use_cache=True, force=False, hash_value=None):
     """Install datasets into msaccess."""
     args = {
         'command': 'install',
@@ -137,14 +137,14 @@ def install_msaccess(dataset, file='access.mdb',
         'table_name': table_name,
         'data_dir': data_dir,
         'force': force,
-        'hash': hash
+        'hash_value': hash_value
     }
     return _install(args, use_cache, debug)
 
 
 def install_json(dataset,
                  table_name='{db}_{table}.json',
-                 data_dir=DATA_DIR, debug=False, use_cache=True, pretty=False, force=False, hash=None):
+                 data_dir=DATA_DIR, debug=False, use_cache=True, pretty=False, force=False, hash_value=None):
     """Install datasets into json."""
     args = {
         'command': 'install',
@@ -154,14 +154,14 @@ def install_json(dataset,
         'data_dir': data_dir,
         'pretty': pretty,
         'force': force,
-        'hash': hash
+        'hash_value': hash_value
     }
     return _install(args, use_cache, debug)
 
 
 def install_xml(dataset,
                 table_name='{db}_{table}.xml',
-                data_dir=DATA_DIR, debug=False, use_cache=True, force=False, hash=None):
+                data_dir=DATA_DIR, debug=False, use_cache=True, force=False, hash_value=None):
     """Install datasets into xml."""
     args = {
         'command': 'install',
@@ -170,6 +170,6 @@ def install_xml(dataset,
         'table_name': table_name,
         'data_dir': data_dir,
         'force': force,
-        'hash': hash
+        'hash_value': hash_value
     }
     return _install(args, use_cache, debug)

--- a/retriever/lib/install.py
+++ b/retriever/lib/install.py
@@ -23,7 +23,7 @@ def _install(args, use_cache, debug):
                                            '{}-{}.zip'.format(args['dataset'], args['hash'][0]))
         if not os.path.exists(path_to_archive):
             print('The committed file does not exist.')
-        engine = install_committed(path_to_archive, engine, force=args['force'])
+        engine = install_committed(path_to_archive, engine, force=args.get('force', False))
         return engine
     script_list = SCRIPT_LIST()
     if not (script_list or os.listdir(SCRIPT_WRITE_PATH)):

--- a/retriever/lib/provenance.py
+++ b/retriever/lib/provenance.py
@@ -44,7 +44,7 @@ def commit_info_for_commit(dataset, commit_message):
     return info
 
 
-def commit_writer(dataset, commit_message, path):
+def commit_writer(dataset, commit_message, path, quiet):
     """
     Creates the committed zipped file
     """
@@ -97,7 +97,7 @@ def commit(dataset, commit_message='', path=None, quiet=False):
     if not quiet:
         print("Committing dataset {}".format(dataset.name))
     try:
-        commit_writer(dataset=dataset, commit_message=commit_message, path=path)
+        commit_writer(dataset=dataset, commit_message=commit_message, path=path, quiet=quiet)
         if not quiet:
             print("Successfully committed.")
     except Exception as e:
@@ -213,6 +213,7 @@ def install_committed(path_to_archive, engine, force=False, quiet=False):
             print(e)
             return
         finally:
+            engine.data_path = None
             rmtree(workdir)
         return engine
 

--- a/test/test_provenance.py
+++ b/test/test_provenance.py
@@ -37,10 +37,11 @@ def get_script_module(script_name):
     return read_json(os.path.join(file_location, script_name))
 
 
-def install_and_commit(script_module, test_dir, commit_message, modified_table_urls={}):
-    for table in modified_table_urls:
-        # modify the url to the csv file
-        setattr(script_module.tables[table], "url", modified_table_urls[table])
+def install_and_commit(script_module, test_dir, commit_message, modified_table_urls=None):
+    if modified_table_urls:
+        for table in modified_table_urls:
+            # modify the url to the csv file
+            setattr(script_module.tables[table], "url", modified_table_urls[table])
     sqlite_engine.opts = {
         "install": "sqlite",
         "file": "test_db.sqlite3",


### PR DESCRIPTION
This will allow installation of committed datasets which have `python` scripts.
I tried to verify several datasets(including vertnet) and it is working fine.
@henrykironde Can you give it a test at your end.