### PR TITLE
Repair auto detect and fetch upstream scripts

### DIFF
--- a/retriever/lib/create_scripts.py
+++ b/retriever/lib/create_scripts.py
@@ -72,12 +72,27 @@ def create_resources(file, skip_lines):
     clean_table = table.__dict__
     resource_dict = {}
     path_to_table = os.path.basename(clean_table["name"])
-    resource_dict["name"] = os.path.splitext(path_to_table)[0]
+    print("Processing... {file_name}".format(file_name=path_to_table))
+    resource_dict["name"] = os.path.splitext(path_to_table)[0].lower()
+    resource_dict["path"] = path_to_table
     resource_dict["schema"] = {}
-    resource_dict["dialect"] = {}
+    resource_dict["dialect"] = {"delimiter": ","}
     resource_dict["schema"]["fields"] = []
     for cname, ctuple in clean_table["columns"]:
-        resource_dict["schema"]["fields"].append({"name": cname, "type": ctuple[0]})
+        if len(ctuple) >= 2:
+            if ctuple[0] == 'char':
+                # char sizes need quotes
+                char_size = "{a}".format(a=ctuple[1])
+                resource_dict["schema"]["fields"].append({"name": cname,
+                                                          "type": ctuple[0],
+                                                          "size": char_size})
+            else:
+                resource_dict["schema"]["fields"].append({"name": cname,
+                                                          "type": ctuple[0],
+                                                          "size": ctuple[1]})
+        else:
+            resource_dict["schema"]["fields"].append({"name": cname,
+                                                      "type": ctuple[0]})
     resource_dict["url"] = "FILL"
     return resource_dict
 
@@ -90,6 +105,7 @@ def create_script_dict(allpacks, path, file, skip_lines):
     allpacks["citation"] = "FILL"
     allpacks["licenses"] = [{"name": "FILL"}]
     allpacks["keywords"] = []
+    allpacks["archived"] = "fill or remove this field if not archived"
     allpacks["homepage"] = "FILL"
     allpacks["version"] = "1.0.0"
     try:
@@ -132,9 +148,14 @@ def process_singles(single_files_path, out_path, skip_lines):
     If the filepath is a directory, creates a single script for each file in the
     directory.
     """
+    if single_files_path.startswith("."):
+        return
+
     if os.path.isdir(single_files_path):
         for path, _, files in os.walk(single_files_path):
             for file_n in files:
+                if file_n.endswith(".json"):
+                    continue
                 allpacks = collections.OrderedDict()
                 if file_n:
                     allpacks = create_script_dict(allpacks, path, file_n, skip_lines)
@@ -150,7 +171,8 @@ def process_singles(single_files_path, out_path, skip_lines):
 
 def write_out_scripts(script_dict, path, out_path):
     """Writes scripts out to a given path"""
-    file_name = os.path.basename(path).split(".")[0] + ".json"
+    names = os.path.basename(path).split(".")[0] + ".json"
+    file_name = names.lower().replace("-", "_")
     path_dir = get_directory(os.path.expanduser(path))
     if out_path is not None:
         path_dir = os.path.expanduser(out_path)

--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -318,14 +318,11 @@ def get_dataset_names_upstream(keywords=None, licenses=None, repo=REPOSITORY):
         version_file = version_file_request.text.splitlines()[1:]
 
         scripts = []
-        max_scripts = 100
         for line in version_file:
             script = line.strip('\n').split(',')[0]
             script = '.'.join(script.split('.')[:-1])
             script = script.replace('_', '-')
             scripts.append(script)
-            if len(scripts) == max_scripts:
-                break
         return sorted(scripts)
 
     result_scripts = set()

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -102,8 +102,9 @@ def test_auto_get_datatypes():
                                    [["ö", 'bb', 'Löve']],
                                    [['a', None], ['b', None], ['c', None]])
     length = test_engine.table.columns
+    # encoded char "?" will return 2 in length
     assert [length[0][1][1], length[1][1][1], length[2][1][1]] == \
-           [101, 102, 104]
+           [2, 2, 5]
 
 
 def test_auto_get_columns_extra_whitespace():


### PR DESCRIPTION
Repair auto detect
    
Include the size of the type where needed.
Use length of encoded string to account for encoded chars
Do not hard code total number of scripts