### PR TITLE
Added Socrata API to retriever, Added tests for the socrata functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ scripts/*.pyc
 .idea*
 *_pycache_
 .vscode/
+docs/_build/
+docs/source/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,16 @@ def to_str(object, object_encoding=encoding):
 
 # Create the .rst file for the available datasets
 datasetfile = open_fw("datasets_list.rst")
-datasetfile_title = """==================
+datasetfile_title = """==============
+APIs Available
+==============
+
+1. **Socrata API**
+------------------
+
+   Total number of datasets supported : 85,244 out of 213,965
+
+==================
 Datasets Available
 ==================
 

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -374,10 +374,11 @@ Do not commit the temporary source directory.
 .. code-block:: bash
 
   cd  docs  # go the docs directory
-  make html # Run
+  make html && python3 -m http.server --directory _build/html
+  # Makes the html files and hosts a HTTP server on localhost:8000 to view the documentation pages locally
 
-  Note:
-  Do not commit the _build directory after making Html.
+.. note::
+  Do not commit the _build directory after making HTML.
 
 **Read The Docs configuration**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Contents:
    pyretriever.rst
    provenance.rst
    datasets_list.rst
+   socrata_api.rst
    developer.rst
    spatial_dbms.rst
    code_of_conduct.rst

--- a/docs/retriever.lib.rst
+++ b/docs/retriever.lib.rst
@@ -156,6 +156,14 @@ retriever.lib.scripts module
     :undoc-members:
     :show-inheritance:
 
+retriever.lib.socrata module
+----------------------------
+
+.. automodule:: retriever.lib.socrata
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 retriever.lib.table module
 --------------------------
 

--- a/docs/socrata_api.rst
+++ b/docs/socrata_api.rst
@@ -1,0 +1,327 @@
+=====================
+Using the Socrata API
+=====================
+
+This tutorial explains the usage of the Socrata API in Data Retriever. It includes both the
+CLI (Command Line Interface) commands as well as the Python interface for the same.
+
+.. note::
+  Currently Data Retriever only supports tabular Socrata datasets (tabular Socrata datasets which are of type map are not supported).
+
+
+Command Line Interface
+======================
+
+Listing the Socrata Datasets
+----------------------------
+
+The ``retriever ls -s`` command displays the Socrata datasets which contain the provided keywords in their title.
+
+$ ``retriever ls -h`` (gives listing options)
+
+::
+
+    usage: retriever ls [-h] [-l L [L ...]] [-k K [K ...]] [-v V [V ...]]
+                    [-s S [S ...]]
+
+    optional arguments:
+      -h, --help    show this help message and exit
+      -l L [L ...]  search datasets with specific license(s)
+      -k K [K ...]  search datasets with keyword(s)
+      -v V [V ...]  verbose list of specified dataset(s)
+      -s S [S ...]  search socrata datasets with name(s)
+
+**Example**
+
+This example will list the names of the socrata datasets which contain the word ``fishing``.
+
+$ ``retriever ls -s fishing``
+
+::
+
+    Autocomplete suggestions : Total 34 results
+
+    [?] Select the dataset name: Recommended Fishing Rivers And Streams
+     > Recommended Fishing Rivers And Streams
+       Recommended Fishing Rivers And Streams API
+       Iowa Fishing Report
+       Recommended Fishing Rivers, Streams, Lakes and Ponds Map
+       Public Fishing Rights Parking Areas Map
+       Fishing Atlas
+       Cook County - Fishing Lakes
+       [ARCHIVED] Fishing License Sellers
+       Public Fishing Rights Parking Areas
+       Recommended Fishing Lakes and Ponds Map
+       Recommended Fishing Lakes and Ponds
+       Delaware Fishing Licenses and Trout Stamps
+       Cook County - Fishing Lakes - KML
+
+Here the user is prompted to select a dataset name. After selecting a dataset, the command returns some information related to the dataset selected.
+
+Let's select the ``Public Fishing Rights Parking Areas`` dataset, after pressing Enter, the command returns
+some information regarding the dataset selected.
+
+::
+
+    Autocomplete suggestions : Total 34 results
+
+    [?] Select the dataset name: Public Fishing Rights Parking Areas
+       Iowa Fishing Report
+       Recommended Fishing Rivers, Streams, Lakes and Ponds Map
+       Fishing Atlas
+       Public Fishing Rights Parking Areas Map
+       [ARCHIVED] Fishing License Sellers
+       Cook County - Fishing Lakes
+     > Public Fishing Rights Parking Areas
+       Recommended Fishing Lakes and Ponds Map
+       Recommended Fishing Lakes and Ponds
+       Delaware Fishing Licenses and Trout Stamps
+       Cook County - Fishing Lakes - KML
+       General Fishing and Salmon Licence Sales
+       Hunting and Fishing License Sellers
+
+    Dataset Information of Public Fishing Rights Parking Areas: Total 1 results
+
+    1. Public Fishing Rights Parking Areas
+      ID : 9vef-6whi
+      Type : {'dataset': 'tabular'}
+      Description : The New York State Department of Environmental Con...
+      Domain : data.ny.gov
+      Link : https://data.ny.gov/Recreation/Public-Fishing-Rights-Parking-Areas/9vef-6whi
+
+
+Downloading the Socrata Datasets
+--------------------------------
+
+The ``retriever download socrata-<socrata id>`` command downloads the Socrata dataset which matches the provided ``socrata id``.
+
+**Example**
+
+From the example in ``Listing the Socrata Datasets`` section, we selected the *Public Fishing Rights Parking Areas* dataset.
+Since the dataset is of type ``tabular``, we can download it. The information received in the previous example contains the ``socrata id``.
+We use this ``socrata id`` to download the dataset.
+
+$ ``retriever download socrata-9vef-6whi``
+
+::
+
+    => Installing socrata-9vef-6whi
+    Downloading 9vef-6whi.csv: 10.0B [00:03, 2.90B/s]
+    Done!
+
+The downloaded raw data files are stored in the ``raw_data`` directory in the ``~/.retriever`` directory.
+
+
+Installing the Socrata Datasets
+-------------------------------
+
+The ``retriever install <engine> socrata-<socrata id>`` command downloads the raw data, creates the script for it and then installs
+the Socrata dataset which matches the provided ``socrata id`` into the provided ``engine``.
+
+**Example**
+
+From the example in ``Listing the Socrata Datasets`` section, we selected the *Public Fishing Rights Parking Areas* dataset.
+Since the dataset is of type ``tabular``, we can install it. The information received in that section contains the ``socrata id``.
+We use this ``socrata id`` to install the dataset.
+
+$ ``retriever install postgres socrata-9vef-6whi``
+
+::
+
+    => Installing socrata-9vef-6whi
+    Downloading 9vef-6whi.csv: 10.0B [00:03, 2.69B/s]
+    Processing... 9vef-6whi.csv
+    Successfully wrote scripts to /home/user/.retriever/socrata-scripts/9vef_6whi.csv.json
+    Updating script name to socrata-9vef-6whi.json
+    Updating the contents of script socrata-9vef-6whi
+    Successfully updated socrata_9vef_6whi.json
+    Creating database socrata_9vef_6whi...
+
+    Bulk insert on ..  socrata_9vef_6whi.socrata_9vef_6whi
+    Done!
+
+The script created for the Socrata dataset is stored in the ``socrata-scripts`` directory in the ``~/.retriever`` directory.
+
+
+Python Interface in Data Retriever
+==================================
+
+Searching Socrata Datasets
+--------------------------
+
+The function ``socrata_autocomplete_search`` takes a list of strings as input and returns a list of strings which are the autocompleted names.
+
+.. code-block:: python
+
+  >>> import retriever as rt
+  >>> names = rt.socrata_autocomplete_search(['clinic', '2015', '2016'])
+  >>> for name in names:
+  ...     print(name)
+  ...
+  2016 & 2015 Clinic Quality Comparisons for Clinics with Five or More Service Providers
+  2015 - 2016 Clinical Quality Comparison (>=5 Providers) by Geography
+  2016 & 2015 Clinic Quality Comparisons for Clinics with Fewer than Five Service Providers
+
+
+Socrata Dataset Info by Dataset Name
+------------------------------------
+
+The input argument for the function ``socrata_dataset_info`` should be a string (valid dataset name returned by ``socrata_autocomplete_search``).
+It returns a list of dicts, because there are multiple datasets on socrata with same name (e.g. ``Building Permits``).
+
+.. code-block:: python
+
+  >>> import retriever as rt
+  >>> resource = rt.socrata_dataset_info('2016 & 2015 Clinic Quality Comparisons for Clinics with Five or More Service Providers')
+  >>> from pprint import pprint
+  >>> pprint(resource)
+  [{'description': 'This data set includes comparative information for clinics '
+                   'with five or more physicians for medical claims in 2015 - '
+                   '2016. \r\n'
+                   '\r\n'
+                   'This data set was calculated by the Utah Department of '
+                   'Health, Office of Healthcare Statistics (OHCS) using Utah’s '
+                   'All Payer Claims Database (APCD).',
+    'domain': 'opendata.utah.gov',
+    'id': '35s3-nmpm',
+    'link': 'https://opendata.utah.gov/Health/2016-2015-Clinic-Quality-Comparisons-for-Clinics-w/35s3-nmpm',
+    'name': '2016 & 2015 Clinic Quality Comparisons for Clinics with Five or '
+            'More Service Providers',
+    'type': {'dataset': 'tabular'}}]
+
+
+Finding Socrata Dataset by Socrata ID
+-------------------------------------
+
+The input argument of the function ``find_socrata_dataset_by_id`` should be the four-by-four socrata dataset identifier (e.g. ``35s3-nmpm``).
+The function returns a dict which contains metadata about the dataset.
+
+.. code-block:: python
+
+  >>> import retriever as rt
+  >>> from pprint import pprint
+  >>> resource = rt.find_socrata_dataset_by_id('35s3-nmpm')
+  >>> pprint(resource)
+  {'datatype': 'tabular',
+   'description': 'This data set includes comparative information for clinics '
+                  'with five or more physicians for medical claims in 2015 - '
+                  '2016. \r\n'
+                  '\r\n'
+                  'This data set was calculated by the Utah Department of '
+                  'Health, Office of Healthcare Statistics (OHCS) using Utah’s '
+                  'All Payer Claims Database (APCD).',
+   'domain': 'opendata.utah.gov',
+   'homepage': 'https://opendata.utah.gov/Health/2016-2015-Clinic-Quality-Comparisons-for-Clinics-w/35s3-nmpm',
+   'id': '35s3-nmpm',
+   'keywords': ['socrata'],
+   'name': '2016 & 2015 Clinic Quality Comparisons for Clinics with Five or More '
+           'Service Providers'}
+
+
+Updating the Contents of Socrata Dataset Script
+-----------------------------------------------
+
+The function ``update_socrata_contents`` updates the contents of the socrata script created by ``create_socrata_dataset``.
+
+The input arguments are:
+  - json_file = The content of the script created
+  - script_name =  The name of the script
+  - url = The url through which the dataset is downloaded
+  - resource = The object returned by the ``find_socrata_dataset_by_id``
+
+The function returns ``True, json_file`` if the resource dict is correct,
+otherwise, it returns ``False, None``.
+
+.. code-block:: python
+
+  import retriever as rt
+  import json
+  from retriever.lib.defaults import SOCRATA_SCRIPT_WRITE_PATH
+
+  resource = rt.find_socrata_dataset_by_id('35s3-nmpm')
+  filename = resource["id"] + '.csv'
+  url = 'https://' + resource["domain"] + '/resource/' + filename
+  script_name = 'socrata-35s3-nmpm'
+  script_path = SOCRATA_SCRIPT_WRITE_PATH
+  script_filename = script_name.replace("-","_") + ".json"
+  with open(f"{script_path}/{script_filename}", "r") as f:
+         json_file = json.load(f)
+  f.close()
+  result, json_file = rt.update_socrata_contents(json_file, script_name, url, resource)
+
+
+Updating and Renaming the Socrata Dataset Script
+------------------------------------------------
+
+The function ``update_socrata_script(script_name, filename, url, resource, script_path)`` renames the script, 
+calls the ``update_socrata_contents``, and then writes the new content returned by ``update_socrata_contents``
+
+.. code-block:: python
+
+  import retriever as rt
+  from retriever.lib.defaults import SOCRATA_SCRIPT_WRITE_PATH
+
+  script_path = SOCRATA_SCRIPT_WRITE_PATH
+  resource = rt.find_socrata_dataset_by_id('35s3-nmpm')
+  filename = resource["id"] + '.csv'
+  url = 'https://' + resource["domain"] + '/resource/' + filename
+  script_name = 'socrata-35s3-nmpm'
+  rt.update_socrata_script(script_name, filename, url, resource, script_path)
+
+
+Creating a Socrata Dataset Script
+---------------------------------
+
+The function ``create_socrata_dataset(engine, name, resource, script_path=None)``
+creates socrata dataset scripts for retriever. This function downloads the raw data, creates the script,
+then updates it and at last, it installs the dataset according to the engine using that script.
+
+.. note::
+
+  If the engine is ``download`` then the function just downloads the raw data files.
+  But if the engine is other than ``download`` (e.g. ``postgres``), then it creates the script
+  and then installs the dataset into the engine provided.
+
+.. code-block:: python
+
+  import retriever as rt
+  from retriever.engines import choose_engine
+  from retriever.lib.defaults import SOCRATA_SCRIPT_WRITE_PATH
+
+  # engine = choose_engine({'command':'install', 'engine':'postgres'})
+  # OR
+  engine = choose_engine({'command': 'download'})
+  script_path = SOCRATA_SCRIPT_WRITE_PATH
+  resource = rt.find_socrata_dataset_by_id('35s3-nmpm')
+  name = 'socrata-35s3-nmpm'
+  rt.create_socrata_dataset(engine, name, resource, script_path)
+
+
+Downloading a Socrata Dataset
+-----------------------------
+
+.. code-block:: python
+
+  import retriever as rt
+  rt.download('socrata-35s3-nmpm')
+
+
+Installing a Socrata Dataset
+----------------------------
+
+.. code-block:: python
+
+  import retriever as rt
+  rt.install_postgres('socrata-35s3-nmpm')
+
+
+.. note::
+
+  For downloading or installing the Socrata Datasets, the dataset should follow the syntax given.
+  The dataset name should be ``socrata-<socrata id>``. The ``socrata id`` should be the four-by-four
+  socrata dataset identifier (e.g. ``35s3-nmpm``).
+
+  Example:
+    - Correct: ``socrata-35s3-nmpm``
+
+    - Incorrect:  ``socrata35s3-nmpm``, ``socrata35s3nmpm``

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ setuptools
 tables
 h5py
 Pillow
+inquirer

--- a/retriever/lib/__init__.py
+++ b/retriever/lib/__init__.py
@@ -21,11 +21,37 @@ from .scripts import get_script_upstream
 from .scripts import get_dataset_names_upstream
 from .scripts import get_script_citation
 from .._version import __version__
+from .socrata import (socrata_autocomplete_search, socrata_dataset_info,
+                      find_socrata_dataset_by_id, create_socrata_dataset,
+                      update_socrata_contents, update_socrata_script)
 
 __all__ = [
-    'check_for_updates', 'commit', 'commit_log', 'create_package', 'datasets',
-    'dataset_names', 'download', 'reload_scripts', 'reset_retriever', 'install_csv',
-    'install_mysql', 'install_postgres', 'install_sqlite', 'install_msaccess',
-    'install_json', 'install_xml', 'install_hdf5', 'fetch', 'get_script_upstream',
-    'get_dataset_names_upstream', 'get_script_citation', "__version__"
+    'check_for_updates',
+    'commit',
+    'commit_log',
+    'create_package',
+    'datasets',
+    'dataset_names',
+    'download',
+    'reload_scripts',
+    'reset_retriever',
+    'install_csv',
+    'install_mysql',
+    'install_postgres',
+    'install_sqlite',
+    'install_msaccess',
+    'install_json',
+    'install_xml',
+    'install_hdf5',
+    'fetch',
+    'get_script_upstream',
+    'get_dataset_names_upstream',
+    'get_script_citation',
+    "__version__",
+    'socrata_autocomplete_search',
+    'socrata_dataset_info',
+    'find_socrata_dataset_by_id',
+    'create_socrata_dataset',
+    'update_socrata_contents',
+    'update_socrata_script',
 ]

--- a/retriever/lib/defaults.py
+++ b/retriever/lib/defaults.py
@@ -1,5 +1,13 @@
 import os
 
+try:
+    from inquirer.themes import load_theme_from_dict
+    INQUIRER_THEME = load_theme_from_dict(
+        {"List": {
+            "selection_color": "black_on_bright_green"
+        }})
+except ModuleNotFoundError:
+    pass
 from retriever._version import __version__
 
 VERSION = __version__
@@ -14,6 +22,7 @@ RETRIEVER_REPOSITORY = RETRIEVER_MAIN_BRANCH
 ENCODING = 'utf-8'
 HOME_DIR = os.path.expanduser('~/.retriever/')
 KAGGLE_TOKEN_PATH = os.path.expanduser('~/.kaggle/kaggle.json')
+SOCRATA_BASE_URL = "http://api.us.socrata.com/api/catalog/v1"
 RETRIEVER_DIR = 'retriever'
 if os.path.exists(os.path.join(HOME_DIR, 'retriever_path.txt')):
     with open(os.path.join(HOME_DIR, 'retriever_path.txt'), 'r') as f:
@@ -25,10 +34,12 @@ if os.path.exists(os.path.join(HOME_DIR, 'retriever_recipes_path.txt')):
 SCRIPT_SEARCH_PATHS = [
     "./", 'scripts',
     os.path.join(RETRIEVER_DIR, 'scripts/'),
+    os.path.join(HOME_DIR, 'socrata-scripts/'),
     os.path.join(RETRIEVER_RECIPES_DIR, 'scripts/'),
     os.path.join(HOME_DIR, 'scripts/')
 ]
 SCRIPT_WRITE_PATH = SCRIPT_SEARCH_PATHS[-1]
+SOCRATA_SCRIPT_WRITE_PATH = SCRIPT_SEARCH_PATHS[3]
 DATA_SEARCH_PATHS = [
     "./",
     "{dataset}",

--- a/retriever/lib/download.py
+++ b/retriever/lib/download.py
@@ -4,6 +4,7 @@ from retriever.engines import choose_engine
 from retriever.lib.defaults import SCRIPT_WRITE_PATH
 from retriever.lib.repository import check_for_updates
 from retriever.lib.scripts import SCRIPT_LIST, name_matches
+from retriever.lib.socrata import find_socrata_dataset_by_id, create_socrata_dataset
 
 
 def download(dataset, path='./', quiet=False, sub_dir='', debug=False, use_cache=True):
@@ -33,6 +34,23 @@ def download(dataset, path='./', quiet=False, sub_dir='', debug=False, use_cache
                 print(e)
                 if debug:
                     raise
+    elif args['dataset'].startswith('socrata') and (scripts is None):
+        socrata_id = args['dataset'].split('-', 1)[1]
+        resource = find_socrata_dataset_by_id(socrata_id)
+
+        if "error" in resource.keys():
+            if resource["datatype"][0] == "map":
+                print("{} because map type datasets are not supported".format(
+                    resource["error"]))
+            else:
+                print("{} because it is of type {} and not tabular".format(
+                    resource["error"], resource["datatype"][1]))
+        elif len(resource.keys()) == 0:
+            return
+        else:
+            print("=> Downloading", args['dataset'])
+            name = f"socrata-{socrata_id}"
+            create_socrata_dataset(engine, name, resource)
     else:
         message = "Run retriever.datasets() to see the list of currently " \
                   "available datasets."

--- a/retriever/lib/engine_tools.py
+++ b/retriever/lib/engine_tools.py
@@ -46,7 +46,10 @@ def create_home_dir():
 
     # create the necessary directory structure for storing scripts/raw_data
     # in the ~/.retriever directory
-    required_dirs = [os.path.join(HOME_DIR, dirs) for dirs in ['', 'raw_data', 'scripts']]
+    required_dirs = [
+        os.path.join(HOME_DIR, dirs)
+        for dirs in ['', 'raw_data', 'scripts', 'socrata-scripts']
+    ]
     for dir in required_dirs:
         if not os.path.exists(dir):
             try:
@@ -67,12 +70,12 @@ def reset_retriever(scope="all", ask_permission=True):
     warning_messages = {
         'all':
             "\nThis will remove existing scripts and cached data."
-            "\nSpecifically it will remove the scripts and raw_data folders "
+            "\nSpecifically it will remove the scripts, socrata-scripts and raw_data folders "
             "in {}\nDo you want to proceed? (y/N)\n",
         'scripts':
             "\nThis will remove existing scripts." +
-            "\nSpecifically it will remove the scripts folder in {}." +
-            "\nDo you want to proceed? (y/N)\n",
+            "\nSpecifically it will remove the scripts and socrata-scripts folders in {}."
+            + "\nDo you want to proceed? (y/N)\n",
         'data':
             "\nThis will remove raw data cached by the Retriever." +
             "\nSpecifically it will remove the raw_data folder in {}." +
@@ -82,6 +85,7 @@ def reset_retriever(scope="all", ask_permission=True):
     path = os.path.normpath(HOME_DIR)
     rw_dir = os.path.normpath(os.path.join(HOME_DIR, 'raw_data'))
     sc_dir = os.path.normpath(os.path.join(HOME_DIR, 'scripts'))
+    soc_dir = os.path.normpath(os.path.join(HOME_DIR, 'socrata-scripts'))
     if scope in ['all', 'scripts', 'data']:
         warn_msg = warning_messages[scope].format(path)
         if ask_permission:
@@ -98,6 +102,8 @@ def reset_retriever(scope="all", ask_permission=True):
             if scope in ['scripts', 'all']:
                 if os.path.exists(sc_dir):
                     shutil.rmtree(sc_dir)
+                if os.path.exists(soc_dir):
+                    shutil.rmtree(soc_dir)
     else:
         dataset_path = os.path.normpath(os.path.join(rw_dir, scope))
         if os.path.exists(dataset_path):
@@ -105,11 +111,16 @@ def reset_retriever(scope="all", ask_permission=True):
         script = scope.replace('-', '_')
         script_path_py = os.path.normpath(os.path.join(sc_dir, script + ".py"))
         script_path_json = os.path.normpath(os.path.join(sc_dir, script + ".json"))
+        socrata_script_path_json = os.path.normpath(
+            os.path.join(soc_dir, script + ".json"))
         if os.path.exists(script_path_py):
             os.remove(script_path_py)
             print("successfully removed the script {scp}".format(scp=scope))
         elif os.path.exists(script_path_json):
             os.remove(script_path_json)
+            print("successfully removed the script {scp}".format(scp=scope))
+        elif os.path.exists(socrata_script_path_json):
+            os.remove(socrata_script_path_json)
             print("successfully removed the script {scp}".format(scp=scope))
         else:
             print("can't find script {scp}".format(scp=scope))

--- a/retriever/lib/get_opts.py
+++ b/retriever/lib/get_opts.py
@@ -124,6 +124,7 @@ ls_parser.add_argument('-k', help='search datasets with keyword(s)',
                        nargs='+').completer = ChoicesCompleter(list(keywords_options))
 ls_parser.add_argument('-v', help='verbose list of specified dataset(s)',
                        nargs='+').completer = ChoicesCompleter(list(scripts_options))
+ls_parser.add_argument('-s', help='search socrata datasets with name(s)', nargs='+')
 
 autocreate_parser.add_argument('path', help='path to the data file(s)')
 autocreate_parser.add_argument('-dt',

--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -178,6 +178,9 @@ def name_matches(scripts, arg):
 
     matches.sort(key=lambda x: -x[1])
 
+    if arg.startswith('socrata') and matches == []:
+        return None
+
     print('\nThe dataset "{}" ' "isn't currently available in the Retriever.".format(arg))
     if matches:
         print("Did you mean:" " \n\t{}".format("\n\t".join([i[0] for i in matches])))

--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -172,7 +172,11 @@ def name_matches(scripts, arg):
         return [read_script]
 
     for script in scripts:
-        script_match_ratio = difflib.SequenceMatcher(None, script.name, arg).ratio()
+        if arg.startswith('socrata') and script.name.startswith('socrata'):
+            script_match_ratio = difflib.SequenceMatcher(None, script.name[8:],
+                                                         arg[8:]).ratio()
+        else:
+            script_match_ratio = difflib.SequenceMatcher(None, script.name, arg).ratio()
         if script_match_ratio > 0.53:
             matches.append((script.name, script_match_ratio))
 
@@ -180,8 +184,10 @@ def name_matches(scripts, arg):
 
     if arg.startswith('socrata') and matches == []:
         return None
+    if not arg.startswith('socrata'):
+        print('\nThe dataset "{}" '
+              "isn't currently available in the Retriever.".format(arg))
 
-    print('\nThe dataset "{}" ' "isn't currently available in the Retriever.".format(arg))
     if matches:
         print("Did you mean:" " \n\t{}".format("\n\t".join([i[0] for i in matches])))
     return None

--- a/retriever/lib/socrata.py
+++ b/retriever/lib/socrata.py
@@ -1,0 +1,248 @@
+import os
+import json
+
+import requests
+from tqdm import tqdm
+from urllib.error import HTTPError
+
+from retriever.lib.create_scripts import create_package
+from retriever.lib.defaults import SOCRATA_BASE_URL, SOCRATA_SCRIPT_WRITE_PATH
+from retriever.lib.scripts import reload_scripts
+from retriever.lib.templates import BasicTextTemplate
+
+
+def url_response(url, params):
+    """Returns the GET response for the given url and params"""
+    return requests.get(
+        url,
+        params,
+        headers={
+            'user-agent':
+                'Weecology/Data-Retriever Package Manager: http://www.data-retriever.org/'
+        },
+        allow_redirects=True,
+        stream=True)
+
+
+def socrata_autocomplete_search(dataset):
+    """Returns the list of dataset names after autocompletion"""
+    names = []
+    query = " ".join(dataset)
+    url = SOCRATA_BASE_URL + '/autocomplete'
+    params = {'q': query}
+    try:
+        response = url_response(url, params)
+
+        if response.status_code == 404:
+            print("Socrata is unable to fetch dataset names currently")
+            return None
+        else:
+            datasets = response.json()
+
+            for i in range(len(datasets["results"])):
+                names.append(datasets["results"][i]["title"])
+
+    except HTTPError as e:
+        print("HTTPError :", e)
+        return None
+
+    return names
+
+
+def socrata_dataset_info(dataset_name):
+    """Returns the dataset information of the dataset name provided"""
+    resources = []
+    url = SOCRATA_BASE_URL
+    params = {'names': dataset_name}
+    try:
+        response = url_response(url, params)
+
+        if response.status_code == 404:
+            print("Socrata is unable to fetch the metadata of {dataset_name}".format(
+                dataset_name=dataset_name))
+            return None
+        else:
+            data = response.json()
+            result = data["results"]
+
+            for i in range(len(result)):
+                resources.append({
+                    "name": result[i]["resource"]["name"],
+                    "id": result[i]["resource"]["id"],
+                    "type": {
+                        result[i]["resource"]["type"]:
+                            result[i]["resource"]["lens_view_type"]
+                    },
+                    "description": result[i]["resource"]["description"],
+                    "domain": result[i]["metadata"]["domain"],
+                    "link": result[i]["link"]
+                })
+
+    except HTTPError as e:
+        print("HTTPError : ", e)
+        return None
+
+    return resources
+
+
+def find_socrata_dataset_by_id(dataset_id):
+    """Returns metadata for the following dataset id"""
+    resource = {}
+    url = SOCRATA_BASE_URL
+    params = {"ids": dataset_id}
+    try:
+        response = url_response(url, params)
+
+        if response.status_code == 400:
+            print(response.json()["error"])
+            return {}
+        elif response.status_code == 200:
+            data = response.json()
+
+            if len(data["results"]):
+                metadata = data["results"][0]
+
+                if (metadata["resource"]["lens_view_type"] !=
+                        "tabular") or (metadata["resource"]["type"] == "map"):
+                    resource["error"] = "Dataset cannot be downloaded using Socrata API"
+                    resource["datatype"] = [
+                        metadata["resource"]["type"],
+                        metadata["resource"]["lens_view_type"]
+                    ]
+
+                elif len(metadata["resource"]["columns_name"]) == 0:
+                    print("Cannot download the dataset using {}".format(dataset_id))
+                    print("Try downloading using its parent id : {}".format(
+                        metadata["resource"]["parent_fxf"][0]))
+                    return resource
+
+                else:
+                    resource["name"] = metadata["resource"]["name"]
+                    resource["id"] = metadata["resource"]["id"]
+                    resource["description"] = metadata["resource"]["description"]
+                    resource["datatype"] = metadata["resource"]["lens_view_type"]
+                    resource["keywords"] = list(
+                        set(metadata["classification"]["categories"] +
+                            metadata["classification"]["tags"])) + ["socrata"]
+                    resource["domain"] = metadata["metadata"]["domain"]
+                    resource["homepage"] = metadata["link"]
+            else:
+                print("No socrata dataset exists for the id : {dataset_id}".format(
+                    dataset_id=dataset_id))
+
+    except HTTPError as e:
+        print("HTTPError : ", e)
+        return {}
+
+    return resource
+
+
+def update_socrata_contents(json_file, script_name, url, resource):
+    """Update the contents of the json script"""
+    if "archived" in json_file.keys():
+        json_file.pop("archived")
+    if all([
+            "resources" in json_file.keys(),
+            len(json_file["resources"]), "path" in json_file["resources"][0].keys()
+    ]):
+        json_file["resources"][0].pop("path")
+
+    keys = ["name", "id", "description", "datatype", "keywords", "domain", "homepage"]
+    for key in keys:
+        if key in resource:
+            flag = True
+        else:
+            flag = False
+    if flag:
+        json_file["description"] = resource["description"]
+        json_file["homepage"] = resource["homepage"]
+        json_file["licenses"] = [{"name": "Public Domain"}]
+        json_file["keywords"] = resource["keywords"]
+        json_file["name"] = script_name
+        json_file["resources"][0]["name"] = script_name.replace("-", "_")
+        json_file["resources"][0]["url"] = url
+        json_file["socrata"] = "True"
+        json_file["title"] = resource["name"]
+        json_file["citation"] = ""
+
+        return True, json_file
+    else:
+        return False, None
+
+
+def update_socrata_script(script_name, filename, url, resource, script_path):
+    """Renames the script name and the contents of the script"""
+    filename = filename.replace("-", "_") + ".json"
+    script_filename = script_name.replace("-", "_") + ".json"
+
+    if filename in [
+            file_i for file_i in os.listdir(script_path) if file_i.endswith(".json")
+    ]:
+        os.rename(f"{script_path}/{filename}", f"{script_path}/{script_filename}")
+        with open(f"{script_path}/{script_filename}", "r") as f:
+            json_file = json.load(f)
+        f.close()
+
+        result, json_file = update_socrata_contents(json_file, script_name, url, resource)
+        if result:
+            json_object = json.dumps(json_file, sort_keys=True, indent=4)
+
+            with open(f"{script_path}/{script_filename}", "w") as f:
+                f.write(json_object)
+            f.close()
+
+            print("Successfully updated {script_filename}".format(
+                script_filename=script_filename))
+        else:
+            print("Could not update {script_filename} with the given resource".format(
+                script_filename=script_filename))
+    else:
+        print("File {filename} does not exist in path {script_path}".format(
+            filename=filename, script_path=script_path))
+
+
+def create_socrata_dataset(engine, name, resource, script_path=SOCRATA_SCRIPT_WRITE_PATH):
+    """Downloads raw data and creates a script for the socrata dataset"""
+    filename = resource["id"] + '.csv'
+    engine.script = BasicTextTemplate(**{"name": name})
+    url = 'https://' + resource["domain"] + '/resource/' + filename
+
+    if not engine.find_file(filename) or not engine.use_cache:
+        path = engine.format_filename(filename)
+        engine.create_raw_data_dir()
+        progbar = tqdm(
+            unit='B',
+            unit_scale=True,
+            unit_divisor=1024,
+            miniters=1,
+            desc='Downloading {}'.format(filename),
+        )
+        result = engine.download_from_socrata(url, path, progbar)
+        if not result:
+            print("Unable to download the dataset using Socrata API")
+
+    elif engine.find_file(filename):
+        path = engine.format_filename(filename)
+        print("File already exists at specified location")
+        print("Keeping existing copy.")
+
+    engine.script = None
+
+    if engine.opts["command"] == "download":
+        return
+    else:
+        if not os.path.exists(script_path):
+            os.makedirs(script_path)
+        file = name.replace("-", "_")
+        if str(file + ".json") in [
+                file_i for file_i in os.listdir(script_path) if file_i.endswith(".json")
+        ]:
+            print(f"Dataset {name} already exists as {file}.json in {script_path}")
+        else:
+            create_package(path, "tabular", True, script_path)
+            print("Updating script name to {}".format(name + ".json"))
+            print("Updating the contents of script {}".format(name))
+            update_socrata_script(name, filename, url, resource, script_path)
+            reload_scripts()
+            print("* You can install {name} to other engines \
+                    using retriever install <engine> {name} *".format(name=name))

--- a/retriever/lib/socrata.py
+++ b/retriever/lib/socrata.py
@@ -20,8 +20,7 @@ def url_response(url, params):
             'user-agent':
                 'Weecology/Data-Retriever Package Manager: http://www.data-retriever.org/'
         },
-        allow_redirects=True,
-        stream=True)
+        allow_redirects=True)
 
 
 def socrata_autocomplete_search(dataset):
@@ -201,8 +200,10 @@ def update_socrata_script(script_name, filename, url, resource, script_path):
             filename=filename, script_path=script_path))
 
 
-def create_socrata_dataset(engine, name, resource, script_path=SOCRATA_SCRIPT_WRITE_PATH):
+def create_socrata_dataset(engine, name, resource, script_path=None):
     """Downloads raw data and creates a script for the socrata dataset"""
+    if script_path is None:
+        script_path = SOCRATA_SCRIPT_WRITE_PATH
     filename = resource["id"] + '.csv'
     engine.script = BasicTextTemplate(**{"name": name})
     url = 'https://' + resource["domain"] + '/resource/' + filename
@@ -223,12 +224,11 @@ def create_socrata_dataset(engine, name, resource, script_path=SOCRATA_SCRIPT_WR
 
     elif engine.find_file(filename):
         path = engine.format_filename(filename)
-        print("File already exists at specified location")
-        print("Keeping existing copy.")
 
     engine.script = None
 
     if engine.opts["command"] == "download":
+        engine.final_cleanup()
         return
     else:
         if not os.path.exists(script_path):
@@ -244,5 +244,3 @@ def create_socrata_dataset(engine, name, resource, script_path=SOCRATA_SCRIPT_WR
             print("Updating the contents of script {}".format(name))
             update_socrata_script(name, filename, url, resource, script_path)
             reload_scripts()
-            print("* You can install {name} to other engines \
-                    using retriever install <engine> {name} *".format(name=name))


### PR DESCRIPTION
## Added the Socrata API
### Total number of datasets supported : 85,244 out of 213,965

- Added `-socrata` flag to `retriever ls` command. Use `retriever ls -socrata <name>` to display a list of suggestions of the dataset name you are looking for. Then, select the dataset name, and the details of the selected dataset name will be displayed.
Example : 
![Screenshot from 2021-06-30 23-31-45](https://user-images.githubusercontent.com/44918472/124009607-705b9180-d9fb-11eb-94da-e8c9669fcd10.png)

- Added `--socrata` flag to `retriever install` and `retriever download` commands. Use `retriever install --socrata <engine> <socrata-id>` to install the socrata dataset which is identified by that `socrata-id`, first it downloads the raw data, creates a script for the data, updates the script accordingly, and then install the script into the engine.
 And use `retriever download --socrata <engine> <socrata-id>` to download the raw data files of the socrata dataset identified by its `socrata-id`.
Example : 
- `retriever download`
![Screenshot from 2021-06-30 23-46-16](https://user-images.githubusercontent.com/44918472/124011264-75b9db80-d9fd-11eb-9579-91088cb38493.png)
- `retriever install`
![Screenshot from 2021-06-30 23-50-36](https://user-images.githubusercontent.com/44918472/124011818-0c869800-d9fe-11eb-8f79-03f6ec3c7598.png)

Added tests for all the Socrata functions.

## Notes:

- `retriever ls -socrata` with an empty input will display the `retriever ls -h -socrata` output. An input with a spelling error will return a list with 0 results.

- `retriever download --socrata <id>` with an incorrectly formatted id would display `Id <id> is incorrectly formatted and will not identify any asset.`

- `retriever download --socrata <id>`, with an `id` that identifies a unsupported dataset will display `Dataset cannot be downloaded using Socrata API because <datatype> type datasets are not supported`

- retriever currently supports only `tabular` type datasets, which excludes `{map: tabular}` datasets.

- Datasets that are `tabular` and do not have any column names in the metadata, will display the following for the `retriever install/download` command:
![Screenshot from 2021-07-01 00-09-46](https://user-images.githubusercontent.com/44918472/124014228-e0b8e180-da00-11eb-96e1-510167bd3421.png)

- If a Socrata dataset is already downloaded, it does not download the data again or its script exists, then the script creation process is not repeated. Example:
![Screenshot from 2021-07-01 00-14-04](https://user-images.githubusercontent.com/44918472/124015005-d5b28100-da01-11eb-9071-541a4a65ae88.png)
 