### PR TITLE
Remove gdal message

### DIFF
--- a/retriever/engines/postgres.py
+++ b/retriever/engines/postgres.py
@@ -5,7 +5,7 @@ try:
     from osgeo import gdal
 except:
     gdal = None
-    print("Install GDAL")
+
 from retriever.lib.models import Engine
 
 


### PR DESCRIPTION
Users who want to resize raster files
are expected to be experts and should
know that Gdal is required as stated in the docs