### PR TITLE
Added kaggle to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setup(
     install_requires=[
         'xlrd',
         'future',
+        'kaggle',
         'argcomplete',
         'tqdm',
         'requests',


### PR DESCRIPTION
Kaggle wasn't in the setup.py which meant the user had to install it with the pip command.

This PR will directly install kaggle when retriever is installed.