### PR TITLE
Added check for empty version string

### DIFF
--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -29,7 +29,7 @@ def check_retriever_minimum_version(module):
     m = module.name
 
     if hasattr(module, "retriever_minimum_version"):
-        if not parse_version(VERSION) >= parse_version("{}".format(mod_ver)):
+        if mod_ver != "" and not parse_version(VERSION) >= parse_version("{}".format(mod_ver)):
             print("{} is supported by Retriever version "
                   "{}".format(m, mod_ver))
             print("Current version is {}".format(VERSION))

--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -29,7 +29,7 @@ def check_retriever_minimum_version(module):
     m = module.name
 
     if hasattr(module, "retriever_minimum_version"):
-        if mod_ver != "" and not parse_version(VERSION) >= parse_version("{}".format(mod_ver)):
+        if mod_ver.strip() and not parse_version(VERSION) >= parse_version("{}".format(mod_ver)):
             print("{} is supported by Retriever version "
                   "{}".format(m, mod_ver))
             print("Current version is {}".format(VERSION))


### PR DESCRIPTION
fixes: #1671 

Just a simple check so that the version regex of setuptools > 66 is not empty.

@ethanwhite 