### PR TITLE
Issue #1660 FIX: Graceful handling of network errors

### DIFF
--- a/retriever/lib/engine.py
+++ b/retriever/lib/engine.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 from math import ceil
 from urllib.request import urlretrieve
 from urllib.error import HTTPError
+import sys
 
 import requests
 from requests.exceptions import InvalidSchema
@@ -495,7 +496,17 @@ class Engine():
                 url.split('/')[-1],
                 filename.partition('.')[0] +
                 "?$query=select%20count(*)%20as%20COLUMN_ALIAS_GUARD__count")
-            row_count = requests.get(row_count_url)
+            try:
+                row_count = requests.get(row_count_url)
+
+            except Exception:
+                red = '\033[91m'
+                bold = '\033[1m'
+                end = '\033[0m'
+
+                print(f"\n{red}{bold}[!] Network Error: {end} {red} Repository cannot be accessed.{end}")
+                print(f"{red}Please check your Internet connection{end}\n")
+                sys.exit(1)
             result = row_count.json()
             rows = result[0]["COLUMN_ALIAS_GUARD__count"]
 
@@ -510,7 +521,8 @@ class Engine():
     def download_response(self, url, path, progbar):
         """Returns True|None according to the download GET response"""
         try:
-            response = requests.get(
+            try:
+                response = requests.get(
                 url,
                 allow_redirects=True,
                 stream=True,
@@ -522,13 +534,27 @@ class Engine():
 
             if response.status_code == 404:
                 print("The data source or server may be redirected or not found")
+            
+            except:
+                red = '\033[91m'
+                bold = '\033[1m'
+                end = '\033[0m'
+
+                print(f"\n{red}{bold}[!] Network Error: {end} {red} Repository cannot be accessed.{end}")
+                print(f"{red}Please check your Internet connection{end}\n")
+                sys.exit(1)
 
         except InvalidSchema:
             try:
                 urlretrieve(url, path, reporthook=reporthook(progbar))
-            except HTTPError as e:
-                print("HTTPError :", e)
-                return None
+            except (HTTPError, URLError, ConnectionResetError) as e:
+                red = '\033[91m'
+                bold = '\033[1m'
+                end = '\033[0m'
+
+                print(f"\n{red}{bold}[!] Network Error: {end} {red} Repository cannot be accessed.{end}")
+                print(f"{red}Please check your Internet connection{end}\n")
+                sys.exit(1)
 
         self.use_cache = True
         progbar.close()

--- a/retriever/lib/fetch.py
+++ b/retriever/lib/fetch.py
@@ -1,6 +1,6 @@
 from retriever.engines.sqlite import engine
 from retriever.lib.defaults import DATA_DIR
-from retriever.lib.install import install_sqlite
+from retriever.lib.install import install_sqlite    
 
 
 def fetch(dataset, file='sqlite.db', table_name='{db}_{table}', data_dir=DATA_DIR):

--- a/retriever/lib/repository.py
+++ b/retriever/lib/repository.py
@@ -1,5 +1,6 @@
 """Checks the repository for updates."""
 import os
+import sys
 import requests
 import imp
 from tqdm import tqdm
@@ -18,7 +19,13 @@ def _download_from_repository(filepath, newpath, repo=REPOSITORY):
                 f.write(chunk)
         r.close()
     except:
-        raise
+        red = '\033[91m'
+        bold = '\033[1m'
+        end = '\033[0m'
+
+        print(f"\n{red}{bold}[!] Network Error: {end} {red} Repository cannot be accessed.{end}")
+        print(f"{red}Please check your Internet connection{end}\n")
+        sys.exit(1)
 
 
 def check_for_updates(repo=REPOSITORY):
@@ -28,7 +35,17 @@ def check_for_updates(repo=REPOSITORY):
     """
     try:
         # open version.txt for current release branch and get script versions
-        version_file = requests.get(repo + "version.txt").text
+        try:
+            version_file = requests.get(repo + "version.txt").text
+        except Exception:
+            red = '\033[91m'
+            bold = '\033[1m'
+            end = '\033[0m'
+
+            print(f"\n{red}{bold}[!] Network Error: {end} {red} Repository cannot be accessed.{end}")
+            print(f"{red}Please check your Internet connection{end}\n")
+            sys.exit(1)
+
         version_file = version_file.splitlines()[1:]
 
         # read scripts from the repository and the checksums from the version.txt

--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -241,12 +241,27 @@ def get_script(dataset):
 def get_data_upstream(search_url):
     """Basic method for getting upstream data"""
     try:
-        r = requests.get(search_url, allow_redirects=True, stream=True)
+        try:
+            r = requests.get(search_url, allow_redirects=True, stream=True)
+        except:
+            red = '\033[91m'
+            bold = '\033[1m'
+            end = '\033[0m'
+
+            print(f"\n{red}{bold}[!] Network Error: {end} {red} Repository cannot be accessed.{end}")
+            print(f"{red}Please check your Internet connection{end}\n")
+            sys.exit(1)
         if r.status_code == 404:
             return None
         return r
     except requests.exceptions.RequestException:
-        return None
+        red = '\033[91m'
+        bold = '\033[1m'
+        end = '\033[0m'
+
+        print(f"\n{red}{bold}[!] Network Error: {end} {red} Repository cannot be accessed.{end}")
+        print(f"{red}Please check your Internet connection{end}\n")
+        sys.exit(1)
 
 
 def get_script_upstream(dataset, repo=REPOSITORY):

--- a/retriever/lib/socrata.py
+++ b/retriever/lib/socrata.py
@@ -13,7 +13,8 @@ from retriever.lib.templates import BasicTextTemplate
 
 def url_response(url, params):
     """Returns the GET response for the given url and params"""
-    return requests.get(
+    try:
+        response = requests.get(
         url,
         params,
         headers={
@@ -22,7 +23,17 @@ def url_response(url, params):
         },
         allow_redirects=True)
 
+        return response
 
+    except:
+            red = '\033[91m'
+            bold = '\033[1m'
+            end = '\033[0m'
+
+            print(f"\n{red}{bold}[!] Network Error: {end} {red} Repository cannot be accessed.{end}")
+            print(f"{red}Please check your Internet connection{end}\n")
+            sys.exit(1)
+    
 def socrata_autocomplete_search(dataset):
     """Returns the list of dataset names after autocompletion"""
     names = []


### PR DESCRIPTION
THE PROBLEM: Currently, when network dependent commands like retriever update and others, the application fails with a standard ConnectionError stack trace. This looks unprofessional and might be confusing for non-technical users.

THE SOLUTION: I have implemented "graceful" error handling mechanism by wrapping the netwrok requests in a try-except block. By doing so,

- Identifies specific connection failures
- Suppresses full traceback
- Prints a clear, user friendly text message in bright red text for the user, indicating that the connection has failed.
- Exits the process without a crash.